### PR TITLE
[SUB-ISSUE] Main-runner > Series 테이블 컬럼 추가 (Flyway)

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_10__create_tb_blog_subscription.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_10__create_tb_blog_subscription.sql
@@ -17,4 +17,4 @@ COMMENT ON COLUMN "blog"."blog_subscription"."created_at" IS '생성일자';
 COMMENT ON COLUMN "blog"."blog_subscription"."updated_at" IS '수정일자';
 
 ALTER TABLE "blog"."blog_subscription" ADD CONSTRAINT "pk_blog_subscription" PRIMARY KEY ("id");
-ALTER TABLE "blog"."blog_subscription" ADD CONSTRAINT "uq_blog_subscription_user_id_blog_id" PRIMARY KEY ("user_id", "blog_id");
+ALTER TABLE "blog"."blog_subscription" ADD CONSTRAINT "uq_blog_subscription_user_id_blog_id" UNIQUE ("user_id", "blog_id");

--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_18__create_tb_series.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_18__create_tb_series.sql
@@ -6,6 +6,8 @@ CREATE TABLE IF NOT EXISTS "series"."series" (
     "id"          BIGSERIAL,
     "blog_id"     BIGINT,
     "title"       VARCHAR(255),
+    "descrition"  VARCHAR(255),
+    "banner"      BYTEA,
     "display_order"  INTEGER,
     "created_at"  TIMESTAMP       DEFAULT NOW(),
     "updated_at"  TIMESTAMP
@@ -18,6 +20,8 @@ COMMENT ON TABLE "series"."series" IS '시리즈';
 COMMENT ON COLUMN "series"."series"."id"                IS '시리즈 PK';
 COMMENT ON COLUMN "series"."series"."blog_id"           IS '블로그 PK';
 COMMENT ON COLUMN "series"."series"."title"             IS '시리즈제목';
+COMMENT ON COLUMN "series"."series"."descrition"        IS '시리즈설명';
+COMMENT ON COLUMN "series"."series"."banner"            IS '시리즈이미지배너';
 COMMENT ON COLUMN "series"."series"."display_order"     IS '사용자정렬순서';
 COMMENT ON COLUMN "series"."series"."created_at"        IS '생성시간';
 COMMENT ON COLUMN "series"."series"."updated_at"        IS '마지막 수정시간';

--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_8__create_tb_refresh_token.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_8__create_tb_refresh_token.sql
@@ -8,12 +8,12 @@ CREATE TABLE "auth"."refresh_token" (
     "expired_at"	TIMESTAMP		NOT NULL
 );
 
-COMMENT ON COLUMN "auth"."user_token"."id"          IS '사용자 토큰 ID';
-COMMENT ON COLUMN "auth"."user_token"."user_id"     IS '사용자 테이블 PK';
-COMMENT ON COLUMN "auth"."user_token"."user_id"     IS '사용자 계정 이름';
-COMMENT ON COLUMN "auth"."user_token"."token"       IS '리프레시 토큰';
-COMMENT ON COLUMN "auth"."user_token"."device_info" IS '로그인 기기 정보';
-COMMENT ON COLUMN "auth"."user_token"."created_at"  IS '토큰 생성 시각';
-COMMENT ON COLUMN "auth"."user_token"."expired_at"  IS '토큰 만료 시각';
+COMMENT ON COLUMN "auth"."refresh_token"."id"          IS '사용자 토큰 ID';
+COMMENT ON COLUMN "auth"."refresh_token"."user_id"     IS '사용자 테이블 PK';
+COMMENT ON COLUMN "auth"."refresh_token"."user_id"     IS '사용자 계정 이름';
+COMMENT ON COLUMN "auth"."refresh_token"."token"       IS '리프레시 토큰';
+COMMENT ON COLUMN "auth"."refresh_token"."device_info" IS '로그인 기기 정보';
+COMMENT ON COLUMN "auth"."refresh_token"."created_at"  IS '토큰 생성 시각';
+COMMENT ON COLUMN "auth"."refresh_token"."expired_at"  IS '토큰 만료 시각';
 
 ALTER TABLE "auth"."refresh_token" ADD CONSTRAINT "pk_refresh_token" PRIMARY KEY ("id");


### PR DESCRIPTION
## Issues

- Resolves #18 

## Description

- Series 테이블에 하기 컬럼을 추가합니다. (V1_0_18__create_tb_series.sql)
   - description [VARCHAR255]: 시리즈 설명
   - banner [BYTEA]: 시리즈 이미지 배너

<br />

## Review Points

<!-- 리뷰어가 중점적으로 확인할 항목을 작성해 주세요. -->
<!-- (Ex: 구현 로직, API 스펙, 테스트 케이스 등) -->

- 이미지 정보를 저장하기 위해 Binary 정보를 저장합니다. Postgre sql은 BLOB 타입은 없고, 대신 BYTEA 컬럼 타입을 씁니다.

<img width="209" height="278" alt="image" src="https://github.com/user-attachments/assets/aaaaa7d5-97c7-432d-ac51-1ca17f079c11" />

<br />

## How Has This Been Tested?

- 없습니다.

<!-- 테스트를 생략하거나, 실행하여 육안으로 확인했다고 쓸 수도 있습니다. -->

<br />

## Additional Notes

- 현재는 파일 서버에 방향이 정해지지 않았으므로 이미지 배너를 binary 데이터로 저장할 수 있도록 하며 변경에 열어둡니다. (시리즈 이미지 배너 -> 시리지 이미지 파일 경로)
