### PR TITLE
Auth > API Docs: Auth Swagger API 문서 제공

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,15 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+
+group=me.nettee
+version=0.1.0
+
+# auth
+auth=:auth
+authApi=:auth:auth-api
+authDomain=:auth:auth-api:auth-domain
+authException=:auth:auth-api:auth-exception
+authReadModel=:auth:auth-api:auth-readmodel
+authApplication=:auth:auth-application
+authRdbAdapter=:auth:auth-rdb-adapter
+authWebMvcAdapter=:auth:auth-webmvc

--- a/monolith/main-runner/build.gradle.kts
+++ b/monolith/main-runner/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 val series: String by project
+val auth: String by project
 
 version = "0.0.1-SNAPSHOT"
 
@@ -13,7 +14,7 @@ dependencies {
 
     // service
     api(project(series))
-
+    api(project(auth))
 
     // webmvc
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/services/auth/auth.settings.gradle.kts
+++ b/services/auth/auth.settings.gradle.kts
@@ -1,0 +1,44 @@
+val auth: String by settings
+val authApi: String by settings
+val authDomain: String by settings
+val authException: String by settings
+val authReadModel: String by settings
+val authApplication: String by settings
+val authRdbAdapter: String by settings
+val authWebMvcAdapter: String by settings
+
+fun getDirectories(vararg names: String): (String) -> File {
+    var dir = rootDir
+    for (name in names) {
+        dir = dir.resolve(name)
+    }
+    return { targetName ->
+        val directory = dir.walkTopDown().maxDepth(3)
+            .filter(File::isDirectory)
+            .associateBy { it.name }
+        directory[targetName] ?: throw Error("그런 폴더가 없습니다: $targetName")
+    }
+}
+
+val authDirectory = getDirectories("services", "auth")
+
+// SERVICE/auth
+include(
+    auth,
+    authApi,
+    authDomain,
+//    authException,
+//    authReadModel,
+    authApplication,
+//    authRdbAdapter,
+    authWebMvcAdapter,
+)
+
+project(auth).projectDir = authDirectory("auth")
+project(authApi).projectDir = authDirectory("api")
+project(authDomain).projectDir = authDirectory("domain")
+//project(authException).projectDir = authDirectory("exception")
+//project(authReadModel).projectDir = authDirectory("readmodel")
+project(authApplication).projectDir = authDirectory("application")
+//project(authRdbAdapter).projectDir = authDirectory("rdb")
+project(authWebMvcAdapter).projectDir = authDirectory("web-mvc")

--- a/services/auth/build.gradle.kts
+++ b/services/auth/build.gradle.kts
@@ -1,0 +1,10 @@
+val authApi: String by project
+val authApplication: String by project
+val authRdbAdapter: String by project
+val authWebMvcAdapter: String by project
+
+dependencies {
+    api(project(authApi))
+    api(project(authApplication))
+    api(project(authWebMvcAdapter))
+}

--- a/services/auth/driving/web-mvc/build.gradle.kts
+++ b/services/auth/driving/web-mvc/build.gradle.kts
@@ -1,0 +1,13 @@
+val authApi: String by project
+val authApplication: String by project
+
+dependencies {
+    api(project(authApi))
+    api(project(authApplication))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // validation
+    compileOnly("jakarta.validation:jakarta.validation-api")
+    compileOnly("jakarta.annotation:jakarta.annotation-api")
+}

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -70,7 +70,7 @@ public class AuthCommandApi {
         // 이메일 인증 코드 전송 로직 구현
     }
 
-    @PostMapping("/email/verification/verify")
+    @PostMapping("/email/verification/check")
     @Operation(
             summary = "이메일 인증코드 확인",
             description = "사용자가 이메일 인증코드를 확인합니다."
@@ -80,7 +80,7 @@ public class AuthCommandApi {
     }
 
     // TODO: 비밀번호 변경 전 재인증 & 비밀번호 변경을 함께 진행할 수도 있음
-    @PostMapping("/password/verify")
+    @PostMapping("/password/verification")
     @Operation(
             summary = "비밀번호 변경 전 재인증",
             description = "사용자가 비밀번호를 변경하기 전에 재인증을 수행합니다."

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthCommandApi {
 
-    @PostMapping("/signUp")
+    @PostMapping("/sign-up")
     @Operation(
             summary = "회원가입",
             description = "일반 사용자를 등록합니다."
@@ -32,7 +32,7 @@ public class AuthCommandApi {
         // 회원 가입 로직 구현
     }
 
-    @PostMapping("/logIn")
+    @PostMapping("/log-in")
     @Operation(
             summary = "로그인",
             description = """
@@ -45,7 +45,7 @@ public class AuthCommandApi {
         return null;
     }
 
-    @PostMapping("/logOut")
+    @PostMapping("/log-out")
     @Operation(summary = "로그아웃", description = "사용자가 로그아웃합니다.")
     public void logOut() {
         // 로그아웃 로직 구현
@@ -108,5 +108,5 @@ public class AuthCommandApi {
         return null;
     }
 
-    // TODO: 추후 자동 로그인, 아이디/비밀번호 찾기 추가 기능 구현 필요
+    // TODO: 아이디/비밀번호 찾기 추가 기능 구현 가능성 있음
 }

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -1,0 +1,112 @@
+package nettee.auth.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import nettee.auth.web.dto.AuthCommandDto.EmailVerifyRequest;
+import nettee.auth.web.dto.AuthCommandDto.EmailVerifySendRequest;
+import nettee.auth.web.dto.AuthCommandDto.LoginRequest;
+import nettee.auth.web.dto.AuthCommandDto.LoginResponse;
+import nettee.auth.web.dto.AuthCommandDto.PasswordResetRequest;
+import nettee.auth.web.dto.AuthCommandDto.PasswordVerifyRequest;
+import nettee.auth.web.dto.AuthCommandDto.SignUpRequest;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthCommandApi {
+
+    @PostMapping("/signUp")
+    @Operation(
+            summary = "회원가입",
+            description = "일반 사용자를 등록합니다."
+    )
+    public void signUp(@RequestBody SignUpRequest signUpRequest) {
+        // 회원 가입 로직 구현
+    }
+
+    @PostMapping("/logIn")
+    @Operation(
+            summary = "로그인",
+            description = """
+                일반 사용자가 로그인합니다.
+                리프레시 토큰(refreshToken)은 HttpOnly 쿠키로 반환합니다.
+            """
+    )
+    public LoginResponse logIn(@RequestBody LoginRequest loginRequest) {
+        // 로그인 로직 구현
+        return null;
+    }
+
+    @PostMapping("/logOut")
+    @Operation(summary = "로그아웃", description = "사용자가 로그아웃합니다.")
+    public void logOut() {
+        // 로그아웃 로직 구현
+    }
+
+    // TODO: loginId가 Unique 하며 NOT NULL 일 시, loginId로 회원 탈퇴를 진행할 수 있도록 변경 가능
+    @DeleteMapping("/auth/withdraw")
+    @Operation(
+            summary = "회원탈퇴",
+            description = "사용자가 탈퇴합니다."
+    )
+    public void withdraw(String userId) {
+        // 회원 탈퇴 구현
+    }
+
+    @PostMapping("/email/verification/send")
+    @Operation(
+            summary = "이메일 인증코드 전송",
+            description = "사용자의 이메일로 인증코드를 전송합니다."
+    )
+    public void sendEmailVerification(@RequestBody EmailVerifySendRequest emailVerifySendRequest) {
+        // 이메일 인증 코드 전송 로직 구현
+    }
+
+    @PostMapping("/email/verification/verify")
+    @Operation(
+            summary = "이메일 인증코드 확인",
+            description = "사용자가 이메일 인증코드를 확인합니다."
+    )
+    public void verifyEmail(@RequestBody EmailVerifyRequest emailVerifyRequest) {
+        // 이메일 인증 코드 확인 로직 구현
+    }
+
+    // TODO: 비밀번호 변경 전 재인증 & 비밀번호 변경을 함께 진행할 수도 있음
+    @PostMapping("/password/verify")
+    @Operation(
+            summary = "비밀번호 변경 전 재인증",
+            description = "사용자가 비밀번호를 변경하기 전에 재인증을 수행합니다."
+    )
+    public void changePassword(@RequestBody PasswordVerifyRequest passwordVerifyRequest) {
+        // 비밀번호 변경 로직 구현
+    }
+
+    @PostMapping("/password/reset")
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "사용자의 비밀번호를 변경합니다."
+    )
+    public void resetPassword(@RequestBody PasswordResetRequest passwordResetRequest) {
+        // 비밀번호 재설정 링크 전송 로직 구현
+    }
+
+    @PostMapping("/token/refresh")
+    @Operation(
+            summary = "액세스 토큰 재발급",
+            description = "리프레시 토큰(HttpOnly 쿠키)을 이용해 새로운 액세스 토큰을 발급받습니다."
+    )
+    public LoginResponse refreshAccessToken(@CookieValue("refreshToken") String refreshToken) {
+        // 액세스 토큰 재발급 로직 구현
+        return null;
+    }
+
+    // TODO: 추후 자동 로그인, 아이디/비밀번호 찾기 추가 기능 구현 필요
+}

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/UserQueryApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/UserQueryApi.java
@@ -1,0 +1,14 @@
+package nettee.auth.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user/query")
+@RequiredArgsConstructor
+public class UserQueryApi {
+
+
+
+}

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
@@ -1,0 +1,67 @@
+package nettee.auth.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public final class AuthCommandDto {
+    private AuthCommandDto() {
+    }
+
+    @Schema(description = "회원가입 요청")
+    public record SignUpRequest(
+            @Schema(description = "사용자 이름", example = "sun")
+            String username,
+            @Schema(description = "로그인 ID", example = "sun123")
+            String loginId,
+            @Schema(description = "비밀번호", example = "Blolet1225!")
+            String password,
+            @Schema(description = "닉네임", example = "sun@gmail.com")
+            String email
+    ) {
+    }
+
+    @Schema(description = "로그인 요청")
+    public record LoginRequest(
+            @Schema(description = "로그인 ID", example = "sun123")
+            String loginId,
+            @Schema(description = "비밀번호", example = "Blolet1225!")
+            String password
+    ) {
+    }
+
+    @Schema(description = "이메일 인증코드 전송 요청")
+    public record EmailVerifySendRequest(
+            @Schema(description = "이메일", example = "sun@gmail.com")
+            String email
+    ) {
+    }
+
+    @Schema(description = "이메일 인증코드 확인 요청")
+    public record EmailVerifyRequest(
+            @Schema(description = "이메일 인증 코드", example = "123456")
+            String verificationCode
+    ) {
+    }
+
+    @Schema(description = "비밀번호 변경 전 재인증 요청")
+    public record PasswordResetRequest(
+            @Schema(description = "현재 사용중인 비밀번호", example = "Blolet1225!")
+            String password
+    ) {
+    }
+
+    @Schema(description = "비밀번호 변경 요청")
+    public record PasswordVerifyRequest(
+            @Schema(description = "변경하고자 하는 비밀번호", example = "Blolet1225!")
+            String password
+    ) {
+    }
+
+    @Schema(description = "로그인 응답")
+    public record LoginResponse(
+            @Schema(description = "로그인 ID", example = "sun123")
+            String loginId,
+            @Schema(description = "액세스 토큰(jwt)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdW4xMjMiLCJpYXQiOjE2NTY1MjY4MDB9.a_XGbI5TW6G5lNO5R4uK_KPOtVz7b5Ue8i6W0Or6BlY")
+            String accessToken
+    ) {
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,3 +5,6 @@ val services = "${rootProject.projectDir}/services"
 apply(from = "common/common.settings.gradle.kts")
 apply(from = "core/core.settings.gradle.kts")
 apply(from = "monolith/monolith.settings.gradle.kts")
+
+// services
+apply(from = "$services/auth/auth.settings.gradle.kts")


### PR DESCRIPTION
## Issues

- Resolves #13 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 목록으로 작성합니다. PR 병합 시 목록의 이슈들이 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- 사용자 인증(Auth) 관련 모듈을 추가했습니다.
  - API 명세 작성을 위한 최소한의 domain 및 web-mvc 모듈 정의
- Auth 도메인에 대한 Swagger API 문서를 작성했습니다.
  - MVP 단계에서 필요한 필수적인 API만 우선 정의되었습니다.
- Auth 비즈니스 로직은 아직 구현되지 않았습니다.


<br />

## Review Points

<!-- 리뷰어가 중점적으로 확인할 항목을 작성해 주세요. -->
<!-- (Ex: 구현 로직, API 스펙, 테스트 케이스 등) -->

- API 문서를 중점으로 확인해주시면 감사하겠습니다!

<br />

## How Has This Been Tested?

- 로컬에서 Swagger API 문서를 확인하였습니다.
  - monolith 모듈에서 auth 모듈에 대한 의존성을 추가 시, API 문서 확인이 가능합니다.
  - http://localhost:8080/swagger-ui/index.html#/


<!-- 테스트를 생략하거나, 실행하여 육안으로 확인했다고 쓸 수도 있습니다. -->

<br />

## Additional Notes