### PR TITLE
Monolith: 로컬에서 너무 잦은 JMX 로그를 줄입니다. (불필요한 운영체제 모니터링 로그를 없앱니다.)

### DIFF
--- a/monolith/main-runner/src/main/resources/application-local.yml
+++ b/monolith/main-runner/src/main/resources/application-local.yml
@@ -17,3 +17,7 @@ spring:
 logging:
   level:
     root: debug
+    # JDK RMI transport, class-loader, and connector activities
+    sun.rmi.transport.tcp: INFO
+    sun.rmi.loader: INFO
+    javax.management.remote.rmi: INFO


### PR DESCRIPTION
## Issues

- Resolves #36

## Description

관련 로깅 레벨을 `INFO`로 설정했습니다.

```yaml
logging:
  level:
    root: debug
    # JDK RMI transport, class-loader, and connector activities
    sun.rmi.transport.tcp: INFO
    sun.rmi.loader: INFO
    javax.management.remote.rmi: INFO
```

<br />

## Review Points

- 상기 작업에 부족한 부분이나 과도한 부분이 없는지 봐 주시면 됩니다.
  - #36 이슈의 로그를 참고해서, 제가 불필요하게 추가한 패키지가 있다면 알려 주세요.
  - 이런 방식 외에 더 디테일한 설정이 필요했다면 말씀해 주세요.

<br />

## How Has This Been Tested?

- 재실행 후 불필요하게 많은 로그가 뜨지 않는 것을 확인했습니다.

<br />
