### PR TITLE
Blog > Swagger: API 문서에서 GET 메서드에 Request Body 대신 Request Param 사용

### DIFF
--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
@@ -1,16 +1,18 @@
 package nettee.blolet.blog.web;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import nettee.blolet.blog.web.dto.BlogQueryDto.BlogDetailViewResponse;
 import nettee.blolet.blog.web.dto.BlogQueryDto.BlogListViewResponse;
-import nettee.blolet.blog.web.dto.BlogQueryDto.BlogOwnerProfileIds;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,7 +31,11 @@ public class BlogQueryApi {
             summary = "블로그 목록 조회 (여러 사용자)",
             description = "선택한 사용자별 블로그 목록을 조회합니다."
     )
-    public BlogListViewResponse findAllByUsernames(@RequestBody BlogOwnerProfileIds profileIds) {
+    public BlogListViewResponse findAllByUsernames(
+            @RequestParam
+            @Schema(description = "사용자 프로필 일련번호 목록", example = "1,2,3")
+            List<String> userProfileIds
+    ) {
         return null;
     }
 

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogQueryDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogQueryDto.java
@@ -8,12 +8,6 @@ import nettee.blolet.blog.readmodel.BlogReadModels.UserProfileBlogs;
 import java.util.List;
 
 public final class BlogQueryDto {
-    @Builder
-    public record BlogOwnerProfileIds(
-//            @Schema(description = "사용자 이름 목록", example = "moon,sun,ho")
-            @Schema(description = "사용자 프로필 일련번호 목록", example = "1,2,3")
-            List<String> userProfileIds
-    ) {}
 
     @Builder
     public record BlogListViewResponse(

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogQueryDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogQueryDto.java
@@ -1,6 +1,5 @@
 package nettee.blolet.blog.web.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import nettee.blolet.blog.readmodel.BlogReadModels.BlogDetail;
 import nettee.blolet.blog.readmodel.BlogReadModels.UserProfileBlogs;


### PR DESCRIPTION
## Issues

- Resolves #40 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 목록으로 작성합니다. PR 병합 시 목록의 이슈들이 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- GET 메서드에 request body를 제거하고, request param으로 받도록 수정했습니다.

<br />

## Review Points

- 간단한 수정입니다. 자유롭게 리뷰해 주세요.

<br />

## How Has This Been Tested?

- 다음처럼 Swagger 문서에 'parameters'로 올바르게 안내되는 것을 확인했습니다.  
    <img width="1080" alt="스웨거 화면 캡처" src="https://github.com/user-attachments/assets/5614af08-2909-4036-a44b-7714f1c660bd" />
- 디버거에서 `BlogQueryApi`의 목록 조회 메서드에 진입 시 다음처럼 `List`로 전달되는 것을 확인했습니다.  
    <img width="930" height="301" alt="디버거에서 변수 목록에 리스트가 올바르게 담긴 것을 확인한 화면 캡처" src="https://github.com/user-attachments/assets/e3d2de6e-7ee4-44b3-bc4a-f759de79c1ea" />

<br />

## Additional Notes

- ❗ 웹 표준 및 관습적인 사용에서 **GET** 메서드는 요청 바디를 갖지 않습니다.
