### PR TITLE
Blog > Application: 블로그 삭제 repository port, use case, service

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogCommandRepositoryPort.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogCommandRepositoryPort.java
@@ -7,5 +7,7 @@ public interface BlogCommandRepositoryPort {
 
     Blog save(Blog blog);
 
+    void deleteById(String id);
+
     int countByUserId(String userId);
 }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
@@ -26,9 +26,14 @@ public class BlogCommandService implements BlogCreateUseCase, BlogUpdateUseCase,
         return commandRepository.save(blog);
     }
 
+    /**
+     *
+     * @param blogId 블로그 아이디
+     * @throws nettee.common.CustomException includes {@code BLOG_NOT_FOUND} error code if target blog doesn't exist.
+     */
     @Override
     public void deleteById(String blogId) {
-        throw new Error("Not implemented yet");
+        commandRepository.deleteById(blogId);
     }
 
     @Override

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogCommandServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.*
 import nettee.blolet.blog.application.port.BlogCommandRepositoryPort
 import nettee.blolet.blog.domain.Blog
 import nettee.blolet.blog.exception.BlogErrorCode.BLOG_MAXIMUM_EXCEEDED
+import nettee.blolet.blog.exception.BlogErrorCode.BLOG_NOT_FOUND
 import nettee.common.CustomException
 import java.time.Instant
 
@@ -92,6 +93,42 @@ class BlogCommandServiceTest : FreeSpec({
                 commandService.save(item)
             }
             exception.errorCode shouldBe BLOG_MAXIMUM_EXCEEDED
+        }
+    }
+
+    "[DELETE] 블로그 삭제 시" - {
+        val targetId = "1"
+
+        // mock:
+        val now = Instant.now()
+        val capturedItems = mutableListOf<Blog>(Blog.builder()
+            .id("1")
+            .userId("USER-1")
+            .name("A Blog")
+            .url("")
+            .createdAt(now)
+            .updatedAt(now)
+            .build()
+        )
+        val firstSize = capturedItems.size
+
+        "✅ 존재하는 아이템은 올바르게 삭제된다." {
+            every { commandPort.deleteById(any()) } answers {
+                val inputtedId: String = firstArg()
+                val exists = capturedItems.map { it.id }.contains(inputtedId)
+                if (!exists) {
+                    throw BLOG_NOT_FOUND.exception()
+                }
+
+                capturedItems.removeIf { it.id == inputtedId }
+            }
+
+            // action
+            commandService.deleteById(targetId)
+
+            // assert
+            capturedItems.size shouldBe firstSize - 1
+            verify(exactly = 1) { commandPort.deleteById(targetId) }
         }
     }
 })

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogCommandServiceTest.kt
@@ -98,6 +98,7 @@ class BlogCommandServiceTest : FreeSpec({
 
     "[DELETE] 블로그 삭제 시" - {
         val targetId = "1"
+        val wrongTargetId = "999"
 
         // mock:
         val now = Instant.now()
@@ -129,6 +130,27 @@ class BlogCommandServiceTest : FreeSpec({
             // assert
             capturedItems.size shouldBe firstSize - 1
             verify(exactly = 1) { commandPort.deleteById(targetId) }
+        }
+
+        "🚧 존재하지 않는 아이템을 삭제하려고 하면 예외를 반환한다." {
+            every { commandPort.deleteById(any()) } answers {
+                val inputtedId: String = firstArg()
+                val exists = capturedItems.map { it.id }.contains(inputtedId)
+                if (!exists) {
+                    throw BLOG_NOT_FOUND.exception()
+                }
+
+                capturedItems.removeIf { it.id == inputtedId }
+            }
+
+            // action & assert
+            val exception = shouldThrow<CustomException> {
+                commandService.deleteById(wrongTargetId)
+            }
+            exception.errorCode shouldBe BLOG_NOT_FOUND
+
+            // verify: port.deleteById 메서드는 실제로 호출되지 않았는지 확인.
+            verify(inverse = true) { commandPort.deleteById(targetId) }
         }
     }
 })


### PR DESCRIPTION
## Issues

- Resolves #56 

<br />

## Description

- 삭제 기능의 use case, port, service 메서드를 추가했습니다.
- 다음 작업의 서브 작업입니다.  
    #9 > #43 

<br />

## Review Points

- 테스트 케이스 위주가 되지 않을까 생각합니다.

<br />

## How Has This Been Tested?

반영한 테스트 케이스는 다음과 같습니다. (service 클래스만 단위 테스트)

- ✅ 존재하는 아이템은 올바르게 삭제된다.
- 🚧 존재하지 않는 아이템을 삭제하려고 하면 예외를 반환한다.  
    <img width="427" height="227" alt="인텔리제이 UI상에 나타난 테스트 결과 캡처" src="https://github.com/user-attachments/assets/c5a9ee1e-a3bb-4177-b918-7a3bfd3da3bd" />
