### PR TITLE
Blog > Domain, API: 구독 도메인 모델 및 에러 코드

### DIFF
--- a/services/blog/api/domain/src/main/java/nettee/blolet/blog/domain/BlogSubscription.java
+++ b/services/blog/api/domain/src/main/java/nettee/blolet/blog/domain/BlogSubscription.java
@@ -1,0 +1,54 @@
+package nettee.blolet.blog.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlogSubscription {
+    private String id;
+    private String userId;
+    private String blogId;
+
+    private Boolean emailAllowed;
+    private Boolean notificationAllowed;
+
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public BlogSubscription(String userId, String blogId, Boolean emailAllowed, Boolean notificationAllowed) {
+        this.userId = userId;
+        this.blogId = blogId;
+        this.emailAllowed = emailAllowed;
+        this.notificationAllowed = notificationAllowed;
+    }
+
+    public void subscribeNewsletter() {
+        this.emailAllowed = true;
+    }
+
+    public void unsubscribeNewsletter() {
+        this.emailAllowed = false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BlogSubscription that)) return false;
+        return Objects.equals(userId, that.userId)
+                && Objects.equals(blogId, that.blogId)
+                && Objects.equals(emailAllowed, that.emailAllowed)
+                && Objects.equals(notificationAllowed, that.notificationAllowed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, blogId, emailAllowed, notificationAllowed);
+    }
+}

--- a/services/blog/api/exception/src/main/java/nettee/blolet/blog/exception/BlogErrorCode.java
+++ b/services/blog/api/exception/src/main/java/nettee/blolet/blog/exception/BlogErrorCode.java
@@ -16,6 +16,8 @@ public enum BlogErrorCode implements ErrorCode {
     // subscription
     ALREADY_SUBSCRIBED_BLOG("이미 구독하였습니다.", HttpStatus.CONFLICT),
     UNSUBSCRIBED_BLOG("이미 구독 취소하거나 아직 구독하지 않은 블로그입니다.", HttpStatus.CONFLICT),
+    ALREADY_SUBSCRIBED_BLOG_NEWSLETTER("이미 뉴스레터를 구독하였습니다.", HttpStatus.CONFLICT),
+    UNSUBSCRIBED_BLOG_NEWSLETTER("이미 구독 취소하거나 아직 구독하지 않은 뉴스레터입니다.", HttpStatus.CONFLICT),
 
     DEFAULT("블로그 API 오류", HttpStatus.INTERNAL_SERVER_ERROR),
     ;

--- a/services/blog/api/exception/src/main/java/nettee/blolet/blog/exception/BlogErrorCode.java
+++ b/services/blog/api/exception/src/main/java/nettee/blolet/blog/exception/BlogErrorCode.java
@@ -12,6 +12,11 @@ public enum BlogErrorCode implements ErrorCode {
     BLOG_NAME_CANNOT_BE_BLANK("블로그 이름은 비워 둘 수 없습니다.", HttpStatus.BAD_REQUEST),
     BLOG_COMMAND_FORBIDDEN("이 블로그를 수정하거나 삭제할 수 없습니다.", HttpStatus.FORBIDDEN),
     BLOG_SUSPENDED("일시정지 된 블로그입니다.", HttpStatus.FORBIDDEN),
+
+    // subscription
+    ALREADY_SUBSCRIBED_BLOG("이미 구독하였습니다.", HttpStatus.CONFLICT),
+    UNSUBSCRIBED_BLOG("이미 구독 취소하거나 아직 구독하지 않은 블로그입니다.", HttpStatus.CONFLICT),
+
     DEFAULT("블로그 API 오류", HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 


### PR DESCRIPTION
## Issues

- Resolves #65 

## Description

- 블로그 구독 도메인 모델
- 구독 관련 에러코드 초안

<br />

## Review Points

- 중개 테이블 역할에 가까우므로 업데이트 메서드는 제한적으로 사용합니다. (뉴스레터 구독이 업데이트고, 블로그 구독 여부는 삽입/삭제)

<br />

## How Has This Been Tested?

- 요구되지 않는 한 도메인 모델만의 테스트는 생략합니다.

<br />

## Additional Notes

_No Response_
