### PR TITLE
Series > rdb > QueryAdapter 개발 

### DIFF
--- a/services/series/driven/rdb/src/main/java/nettee/series/article/driven/rdb/persistence/SeriesArticleQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/article/driven/rdb/persistence/SeriesArticleQueryAdapter.java
@@ -1,0 +1,36 @@
+package nettee.series.article.driven.rdb.persistence;
+
+import nettee.series.article.application.port.SeriesArticleQueryRepositoryPort;
+import nettee.series.article.driven.rdb.entity.SeriesArticleEntity;
+import nettee.series.article.driven.rdb.persistence.mapper.SeriesArticleEntityMapper;
+import nettee.series.article.readmodel.SeriesArticleQueryModels.SeriesArticleSummary;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static nettee.series.article.driven.rdb.entity.QSeriesArticleEntity.seriesArticleEntity;
+
+@Repository
+public class SeriesArticleQueryAdapter extends QuerydslRepositorySupport implements SeriesArticleQueryRepositoryPort {
+
+    private final SeriesArticleEntityMapper seriesArticleEntityMapper;
+
+    public SeriesArticleQueryAdapter(final SeriesArticleEntityMapper seriesArticleEntityMapper) {
+        super(SeriesArticleEntity.class);
+        this.seriesArticleEntityMapper = seriesArticleEntityMapper;
+    }
+
+    @Override
+    public List<SeriesArticleSummary> findBySeriesId(String seriesId) {
+        var articleList = getQuerydsl().createQuery()
+                .select(seriesArticleEntity)
+                .from(seriesArticleEntity)
+                .where(seriesArticleEntity.seriesId.eq(Long.valueOf(seriesId)))
+                .fetch();
+
+        return articleList.stream()
+                .map(seriesArticleEntityMapper::toSeriesArticleSummary)
+                .toList();
+    }
+}

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
@@ -1,0 +1,54 @@
+package nettee.series.driven.rdb.persistence;
+
+import com.querydsl.core.types.Projections;
+import nettee.series.application.port.SeriesQueryRepositoryPort;
+import nettee.series.driven.rdb.entity.SeriesEntity;
+import nettee.series.driven.rdb.persistence.mapper.SeriesEntityMapper;
+import nettee.series.readmodel.SeriesQueryModels.SeriesSummary;
+import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static nettee.series.driven.rdb.entity.QSeriesEntity.seriesEntity;
+
+@Repository
+public class SeriesQueryAdapter extends QuerydslRepositorySupport implements SeriesQueryRepositoryPort {
+    
+    private final SeriesEntityMapper seriesEntityMapper;
+    
+    public SeriesQueryAdapter(final SeriesEntityMapper seriesEntityMapper) {
+        super(SeriesEntity.class);
+        this.seriesEntityMapper = seriesEntityMapper;
+    }
+    
+    @Override
+    public Optional<SeriesDetail> findBySeriesId(String seriesId) {
+        return seriesEntityMapper.toOptionalSeriesDetail(
+                getQuerydsl().createQuery()
+                        .select(seriesEntity)
+                        .from(seriesEntity)
+                        .where(seriesEntity.id.eq(Long.valueOf(seriesId)))
+                        .fetchOne()
+        );
+    }
+    
+    @Override
+    public List<SeriesSummary> findAllByBlogId(String blogId) {
+        return getQuerydsl().createQuery()
+                .select(Projections.constructor(
+                        SeriesSummary.class,
+                        seriesEntity.id.stringValue(),
+                        seriesEntity.blogId.stringValue(),
+                        seriesEntity.title,
+                        seriesEntity.displayOrder,
+                        seriesEntity.createdAt,
+                        seriesEntity.updatedAt
+                ))
+                .from(seriesEntity)
+                .where(seriesEntity.blogId.eq(Long.valueOf(blogId)))
+                .fetch();
+    }
+}

--- a/services/series/driven/rdb/src/test/kotlin/nettee/series/article/driven/rdb/persistence/SeriesArticleQueryAdapterTest.kt
+++ b/services/series/driven/rdb/src/test/kotlin/nettee/series/article/driven/rdb/persistence/SeriesArticleQueryAdapterTest.kt
@@ -1,0 +1,56 @@
+package nettee.series.article.driven.rdb.persistence
+
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import nettee.series.article.driven.rdb.entity.SeriesArticleEntity
+import nettee.series.article.driven.rdb.persistence.mapper.SeriesArticleEntityMapper
+import nettee.series.driven.rdb.jpa.JpaTransactionalFreeSpec
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.ComponentScan
+
+@DataJpaTest
+@ComponentScan(basePackageClasses = [SeriesArticleEntityMapper::class])
+class SeriesArticleQueryAdapterTest(
+    @Autowired private val seriesArticleJpaRepository: SeriesArticleJpaRepository,
+    @Autowired private val mapper: SeriesArticleEntityMapper,
+    @Autowired private val entityManager: EntityManager,
+) : JpaTransactionalFreeSpec({
+
+    val adapter = SeriesArticleQueryAdapter(mapper)
+
+    adapter.setEntityManager(entityManager)
+
+    val testSeriesId = "1"
+    val testDraftId = 100L
+    val testArticleId = 200L
+
+    "[정상] findBySeriesId - 시리즈 ID로 조회" - {
+        val result = adapter.findBySeriesId(testSeriesId)
+
+        "조회된 결과 개수는 2개여야 한다" {
+            result.size shouldBe 2
+        }
+
+        "조회된 결과의 필드가 일치해야 한다" {
+            result[0].seriesId shouldBe testSeriesId
+            result[0].draftId shouldBe testDraftId.toString()
+            result[0].articleId shouldBe testArticleId.toString()
+
+            result[1].seriesId shouldBe testSeriesId
+            result[1].draftId shouldBe (testDraftId + 1).toString()
+            result[1].articleId shouldBe (testArticleId + 1).toString()
+        }
+    }
+
+    beforeSpec {
+        (0..1).forEach {
+            val entity = SeriesArticleEntity().apply {
+                seriesId = testSeriesId.toLong()
+                draftId = testDraftId + it
+                articleId = testArticleId + it
+            }
+            seriesArticleJpaRepository.save(entity)
+        }
+    }
+})

--- a/services/series/driven/rdb/src/test/kotlin/nettee/series/driven/rdb/persistence/SeriesQueryAdapterTest.kt
+++ b/services/series/driven/rdb/src/test/kotlin/nettee/series/driven/rdb/persistence/SeriesQueryAdapterTest.kt
@@ -1,0 +1,65 @@
+package nettee.series.driven.rdb.persistence
+
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import nettee.series.driven.rdb.entity.SeriesEntity
+import nettee.series.driven.rdb.jpa.JpaTransactionalFreeSpec
+import nettee.series.driven.rdb.persistence.mapper.SeriesEntityMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.ComponentScan
+
+@DataJpaTest
+@ComponentScan(basePackageClasses = [SeriesEntityMapper::class])
+class SeriesQueryAdapterTest(
+    @Autowired private val entityManager: EntityManager,
+    @Autowired private val seriesEntityMapper: SeriesEntityMapper,
+    @Autowired private val seriesJpaRepository: SeriesJpaRepository
+) : JpaTransactionalFreeSpec({
+
+    val adapter = SeriesQueryAdapter(seriesEntityMapper)
+
+    adapter.setEntityManager(entityManager)
+
+    val testBlogId = 123L
+    val seriesId = 1L
+
+    "[정상] findBySeriesId - 존재하는 경우" - {
+        val result = adapter.findBySeriesId(seriesId.toString())
+
+        "Optional 값이 존재해야 한다" {
+            result.isPresent shouldBe true
+        }
+
+        "값이 일치해야 한다" {
+            val detail = result.get()
+            detail.id shouldBe seriesId.toString()
+            detail.title shouldBe "테스트 시리즈"
+        }
+    }
+
+    "[정상] findAllByBlogId - 블로그 ID로 전체 조회" - {
+        val result = adapter.findAllByBlogId(testBlogId.toString())
+
+        "결과는 2건이어야 한다" {
+            result.size shouldBe 2
+        }
+
+        "값이 일치해야 한다" {
+            result[0].blogId shouldBe testBlogId.toString()
+            result[1].blogId shouldBe testBlogId.toString()
+        }
+    }
+
+    beforeSpec {
+        (0..1).forEach {
+            val entity = SeriesEntity().apply {
+                blogId = testBlogId
+                title = "테스트 시리즈"
+                description = "설명입니다"
+                displayOrder = 1
+            }
+            seriesJpaRepository.save(entity)
+        }
+    }
+})


### PR DESCRIPTION
## Issues

- Resolves #86
<!-- 이 PR이 완전히 처리한 이슈의 번호를 목록으로 작성합니다. PR 병합 시 목록의 이슈들이 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- [x] 시리즈 단건 조회
- [x] 시리즈 다건 조회
- [x] 시리즈 아티클 목록 조회
- [x] API 테스트 코트 작성

<br />

## Review Points

- 프로젝션을 사용하여 성능을 고려하였습니다.
```java
    @Override
    public List<SeriesSummary> findAllByBlogId(String blogId) {
        return getQuerydsl().createQuery()
                .select(Projections.constructor(
                        SeriesSummary.class,
                        seriesEntity.id.stringValue(),
                        seriesEntity.blogId.stringValue(),
                        seriesEntity.title,
                        seriesEntity.displayOrder,
                        seriesEntity.createdAt,
                        seriesEntity.updatedAt
                ))
                .from(seriesEntity)
                .where(seriesEntity.blogId.eq(Long.valueOf(blogId)))
                .fetch();
    }
```

<br />

## How Has This Been Tested?

- 테스트 설정은 src/test를 확인해주시면 감사합니다.

[SeriesQueryAdpaterTest.kt]
<img width="442" height="350" alt="image" src="https://github.com/user-attachments/assets/ed53161f-c040-45ca-a2a4-0f3cb5cd1035" />

[SeriesArticleAdapterTest.kt]
<img width="243" height="119" alt="image" src="https://github.com/user-attachments/assets/b4ba7a7e-7afa-43e1-acbb-703da6c089ea" />


<br />

## Additional Notes

- 없습니다.
