### PR TITLE
CORE > jpa-core: JPAQueryFactory 빈 등록

### DIFF
--- a/core/jpa-core/src/main/java/nettee/jpa/config/QueryDslConfig.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package nettee.jpa.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## Issues

- Resolves #95 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 목록으로 작성합니다. PR 병합 시 목록의 이슈들이 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- [x] JPAQueryFactory 빈 등록을 위한 QueryDslConfig 추가

<br />

## Review Points

<!-- 리뷰어가 중점적으로 확인할 항목을 작성해 주세요. -->
<!-- (Ex: 구현 로직, API 스펙, 테스트 케이스 등) -->

- 하기와 같은 유연한 구조를 짤 수 있게 됐습니다.
- 개발자 인원들은 QueryDslSupport 상속 혹은 JPAQueryFactory 을 주입 2가지 중에 택 1을 하시면 좋을 것 같습니다.

```java
@Repository
@RequiredArgsConstructor
public class SeriesQueryAdapter implements SeriesQueryRepositoryPort {
    
    private final SeriesEntityMapper seriesEntityMapper;
    private final JPAQueryFactory queryFactory;
    
    @Override
    public Optional<SeriesDetail> findBySeriesId(String seriesId) {
        return seriesEntityMapper.toOptionalSeriesDetail(
                queryFactory.select(seriesEntity)
                        .from(seriesEntity)
                        .where(seriesEntity.id.eq(Long.valueOf(seriesId)))
                        .fetchOne()
        );
    }
```

<br />

## How Has This Been Tested?

- Postman을 통한 정상 동작을 확인하였습니다.
<img width="448" height="425" alt="image" src="https://github.com/user-attachments/assets/839cf114-e51c-4b18-944c-8d8c4c07ef17" />

<!-- 테스트를 생략하거나, 실행하여 육안으로 확인했다고 쓸 수도 있습니다. -->

<br />

## Additional Notes

- 없습니다.
