### PR TITLE
Auth > Application: 로그인

### DIFF
--- a/services/auth/api/domain/src/main/java/nettee/auth/domain/User.java
+++ b/services/auth/api/domain/src/main/java/nettee/auth/domain/User.java
@@ -29,4 +29,8 @@ public class User {
             throw new IllegalArgumentException("필수 약관에 동의하지 않았습니다.");
         }
     }
+
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
 }

--- a/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
+++ b/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
@@ -7,8 +7,11 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public enum AuthErrorCode implements ErrorCode {
-    AUTH_ACCOUNT_ALREADY_EXIST("이미 존재하는 계정입니다.", HttpStatus.CONFLICT);
-
+    AUTH_ACCOUNT_ALREADY_EXIST("이미 존재하는 계정입니다.", HttpStatus.CONFLICT),
+    AUTH_ACCOUNT_NOT_FOUND("사용자 계정을 찾을 수 없습니다.", HttpStatus.LOCKED),
+    AUTH_PASSWORD_MISMATCHED("사용자 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    ;
+    
     private final String message;
     private final HttpStatus httpStatus;
 

--- a/services/auth/api/readmodel/src/main/java/nettee/blolet/auth/readmodel/AuthCommandModels.java
+++ b/services/auth/api/readmodel/src/main/java/nettee/blolet/auth/readmodel/AuthCommandModels.java
@@ -1,5 +1,7 @@
 package nettee.blolet.auth.readmodel;
 
+import lombok.Builder;
+
 public final class AuthCommandModels {
 
     public record SignUpRequestModel(
@@ -10,6 +12,13 @@ public final class AuthCommandModels {
 
             boolean agreedTerms,    // 이용약관 동의
             boolean agreedPrivacy   // 개인정보처리방침 동의
+    ) {
+    }
+
+    @Builder
+    public record LoginTokenModel(
+            String accessToken,
+            String refreshToken
     ) {
     }
 }

--- a/services/auth/application/build.gradle.kts
+++ b/services/auth/application/build.gradle.kts
@@ -3,5 +3,5 @@ val authApi: String by project
 dependencies {
     api(project(authApi))
     api(project(":security-password"))
-    implementation("org.springframework.security:spring-security-crypto")
+    api(project(":security-jwt-issuer"))
 }

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthRedisPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthRedisPort.java
@@ -1,0 +1,5 @@
+package nettee.auth.port;
+
+public interface AuthRedisPort {
+    void saveRefreshToken(String refreshTokenKey, String refreshToken);
+}

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -110,7 +110,7 @@ public class AuthCommandService implements AuthSignUsecase {
 
         // refreshToken 발급
         String refreshToken = generateSecureRandom();
-        String hashedRefreshToken = hashSHA256(refreshToken);
+        String hashedRefreshToken = hashSha256(refreshToken);
         String hashedRefreshTokenKey = userEntity.getId() + ":" + hashedRefreshToken;
 
         // refreshToken 저장
@@ -125,7 +125,7 @@ public class AuthCommandService implements AuthSignUsecase {
     /**
      * SHA-256 해시 함수를 사용하여 문자열을 해싱합니다.
      */
-    private String hashSHA256(String token) {
+    private String hashSha256(String token) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -1,15 +1,27 @@
 package nettee.auth.service;
 
-import static nettee.auth.exception.AuthErrorCode.AUTH_ACCOUNT_ALREADY_EXIST;
 
+import static nettee.auth.exception.AuthErrorCode.AUTH_ACCOUNT_ALREADY_EXIST;
+import static nettee.auth.exception.AuthErrorCode.AUTH_ACCOUNT_NOT_FOUND;
+import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_MISMATCHED;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import nettee.auth.domain.User;
 import nettee.auth.domain.UserStatus;
 import nettee.auth.exception.AuthException;
 import nettee.auth.port.AuthCommandRepositoryPort;
 import nettee.auth.port.AuthQueryRepositoryPort;
+import nettee.auth.port.AuthRedisPort;
 import nettee.auth.usecase.AuthSignUsecase;
+import nettee.blolet.auth.readmodel.AuthCommandModels.LoginTokenModel;
 import nettee.blolet.auth.readmodel.AuthCommandModels.SignUpRequestModel;
+import nettee.jwt.JwtIssuer;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -20,8 +32,12 @@ public class AuthCommandService implements AuthSignUsecase {
 
     private final AuthCommandRepositoryPort authCommandRepositoryPort;
     private final AuthQueryRepositoryPort authQueryRepositoryPort;
+    private final AuthRedisPort authRedisPort;
 
     private final PasswordEncoder passwordEncoder;
+    private final JwtIssuer jwtIssuer;
+
+    private static final int ACCESS_TOKEN_EXPIRATION = 600; // accessToken 유효 기간
 
     @Override
     public void signUp(SignUpRequestModel model) {
@@ -47,7 +63,6 @@ public class AuthCommandService implements AuthSignUsecase {
             throw new AuthException(AUTH_ACCOUNT_ALREADY_EXIST);
         }
 
-
         // 3. password 암호화 (Argon2id, 가변 솔트 사용)
         String encodedPassword = passwordEncoder.encode(model.password());
 
@@ -62,5 +77,70 @@ public class AuthCommandService implements AuthSignUsecase {
 
         // 5. user 저장
         authCommandRepositoryPort.save(user);
+    }
+
+    @Override
+    public LoginTokenModel signIn(String loginId, String rawPassword) throws AuthException {
+        // 1. login ID로 사용자 조회
+        User userEntity = authQueryRepositoryPort.findByLoginId(loginId)
+                .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(rawPassword, userEntity.getEncodedPassword())) {
+            throw new AuthException(AUTH_PASSWORD_MISMATCHED);
+        }
+
+        // 3. 사용자 인증 성공 시, accessToken & refreshToken 발급
+        return generateLoginToken(userEntity);
+    }
+
+    /**
+     * 로그인 성공 시, accessToken과 refreshToken을 발급합니다.
+     * accessToken은 JWT 형식으로 발급되며, refreshToken은 암호화된 형태로 Redis에 저장합니다.
+     */
+    private LoginTokenModel generateLoginToken(User userEntity) {
+        // accessToken 발급
+        Map<String, Object> claims = Map.of(
+                "userId", userEntity.getId()
+        );
+        String accessToken = jwtIssuer.issue(userEntity.getId(), claims, ACCESS_TOKEN_EXPIRATION);
+
+        // refreshToken 발급
+        String refreshToken = generateSecureRandom();
+        String hashedRefreshToken = hashSHA256(refreshToken);
+        String hashedRefreshTokenKey = userEntity.getId() + ":" + hashedRefreshToken;
+
+        // refreshToken 저장
+        authRedisPort.saveRefreshToken(hashedRefreshTokenKey, hashedRefreshToken);
+
+        return LoginTokenModel.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    /**
+     * SHA-256 해시 함수를 사용하여 문자열을 해싱합니다.
+     */
+    private String hashSHA256(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 암호학적으로 안전한 난수를 생성합니다. (uuid보다 안전)
+     */
+    private String generateSecureRandom() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] randomBytes = new byte[32];
+        secureRandom.nextBytes(randomBytes);
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     }
 }

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -40,7 +40,7 @@ public class AuthCommandService implements AuthSignUsecase {
     private static final int ACCESS_TOKEN_EXPIRATION = 600; // accessToken 유효 기간
 
     @Override
-    public void signUp(SignUpRequestModel model) {
+    public LoginTokenModel signUp(SignUpRequestModel model) {
         /**
          * TODO: 회원가입 이메일 인증을 정상적으로 수행했는지 검증
          * 사용자 이메일 인증이 완료되었음을 확인하는 토큰을 받을 수 있다.
@@ -77,6 +77,9 @@ public class AuthCommandService implements AuthSignUsecase {
 
         // 5. user 저장
         authCommandRepositoryPort.save(user);
+
+        // 6. 회원가입 성공 시, 자동 로그인 처리를 위해 accessToken & refreshToken 발급
+        return generateLoginToken(user);
     }
 
     @Override

--- a/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
+++ b/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
@@ -4,6 +4,6 @@ import nettee.blolet.auth.readmodel.AuthCommandModels.LoginTokenModel;
 import nettee.blolet.auth.readmodel.AuthCommandModels.SignUpRequestModel;
 
 public interface AuthSignUsecase {
-    void signUp(SignUpRequestModel signUpRequest);
+    LoginTokenModel signUp(SignUpRequestModel signUpRequest);
     LoginTokenModel signIn(String loginId, String password);
 }

--- a/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
+++ b/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
@@ -1,7 +1,9 @@
 package nettee.auth.usecase;
 
+import nettee.blolet.auth.readmodel.AuthCommandModels.LoginTokenModel;
 import nettee.blolet.auth.readmodel.AuthCommandModels.SignUpRequestModel;
 
 public interface AuthSignUsecase {
     void signUp(SignUpRequestModel signUpRequest);
+    LoginTokenModel signIn(String loginId, String password);
 }


### PR DESCRIPTION
## Issues

- Resolves #80 
- Resolves #82 

## Description

- 사용자 일반 로그인 구현

<br />

## Review Points

- DB 유출 시 refresh token을 바로 재사용 하지 못하도록, 해싱된 값이 저장되도록 구현하였습니다.
- 회원가입 이후 로그인 상태를 유지할 수 있도록, access / refresh token을 반환하도록 수정하였습니다.

<br />

## How Has This Been Tested?

- 테스트는 생략하였습니다. (추후 작업 예정)