### PR TITLE
Blog > WebMVC: 구독 응답 DTO가 Application 계층이 제공하는 `SubscriptionStats` 데이터에 의존하도록 수정

### DIFF
--- a/services/blog/driving/web-mvc/build.gradle.kts
+++ b/services/blog/driving/web-mvc/build.gradle.kts
@@ -3,4 +3,5 @@ val blogApplication: String by project
 
 dependencies {
     api(project(blogApi))
+    api(project(blogApplication))
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
@@ -2,6 +2,7 @@ package nettee.blolet.blog.web.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
 import nettee.blolet.blog.readmodel.BlogReadModels.BlogDetail;
 
 public final class BlogCommandDto {
@@ -16,22 +17,14 @@ public final class BlogCommandDto {
     public record BlogUpdateResponse(BlogDetail blog) {}
 
     @Builder
-    public record BlogSubscribeResponse(SubscriptionCount counts) {}
+    public record BlogSubscribeResponse(SubscriptionStats counts) {}
 
     @Builder
-    public record BlogUnsubscribeResponse(SubscriptionCount counts) {}
+    public record BlogUnsubscribeResponse(SubscriptionStats counts) {}
 
     @Builder
-    public record BlogNewsletterSubscribeResponse(SubscriptionCount counts) {}
+    public record BlogNewsletterSubscribeResponse(SubscriptionStats counts) {}
 
     @Builder
-    public record BlogNewsletterUnsubscribeResponse(SubscriptionCount counts) {}
-
-    @Builder
-    public record SubscriptionCount(
-            @Schema(description = "이 블로그를 구독한 사용자 수", example = "999")
-            Integer totalSubscribers,
-            @Schema(description = "사용자가 구독한 블로그 수", example = "99")
-            Integer userSubscriptions
-    ) {}
+    public record BlogNewsletterUnsubscribeResponse(SubscriptionStats counts) {}
 }


### PR DESCRIPTION
## Issues

- Resolves #109 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 목록으로 작성합니다. PR 병합 시 목록의 이슈들이 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- 구독자 수 관련 응답 DTO가 애플리케이션의 `SubscriptionStats` 모델에 의존합니다.
- Issue Breadcrumb: #9 > #43 

<br />

## Review Points

- 리팩토링된 부분만 살펴봐 주시면 좋을 것 같습니다.

<br />

## How Has This Been Tested?

- 테스트는 생략했습니다.

<br />
