### PR TITLE
Blog > Application: 블로그 구독 취소

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -34,13 +34,7 @@ public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, 
         commandRepository.save(subscription);
 
         // 저장 후 통계 조회
-        int userCount = commandRepository.countByUserId(userId);
-        int blogCount = commandRepository.countByBlogId(blogId);
-
-        return SubscriptionStats.builder()
-                .userSubscriptionCount(userCount)
-                .blogTotalSubscriberCount(blogCount)
-                .build();
+        return subscriptionStats(userId, blogId);
     }
 
     @Override
@@ -48,5 +42,15 @@ public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, 
         BlogSubscription subscription = commandRepository.findByUserIdAndBlogId(userId, blogId)
                 .orElseThrow(UNSUBSCRIBED_BLOG::exception);
         commandRepository.deleteById(subscription.getId());
+    }
+
+    private SubscriptionStats subscriptionStats(String userId, String blogId) {
+        int userCount = commandRepository.countByUserId(userId);
+        int blogCount = commandRepository.countByBlogId(blogId);
+
+        return SubscriptionStats.builder()
+                .userSubscriptionCount(userCount)
+                .blogTotalSubscriberCount(blogCount)
+                .build();
     }
 }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -44,8 +44,8 @@ public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, 
     }
 
     @Override
-    public void unsubscribeBlog(String username, String blogId) {
-        BlogSubscription subscription = commandRepository.findByUserIdAndBlogId(username, blogId)
+    public void unsubscribeBlog(String userId, String blogId) {
+        BlogSubscription subscription = commandRepository.findByUserIdAndBlogId(userId, blogId)
                 .orElseThrow(UNSUBSCRIBED_BLOG::exception);
         commandRepository.deleteById(subscription.getId());
     }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -9,6 +9,7 @@ import nettee.blolet.blog.domain.BlogSubscription;
 import org.springframework.stereotype.Service;
 
 import static nettee.blolet.blog.exception.BlogErrorCode.ALREADY_SUBSCRIBED_BLOG;
+import static nettee.blolet.blog.exception.BlogErrorCode.UNSUBSCRIBED_BLOG;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +45,8 @@ public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, 
 
     @Override
     public void unsubscribeBlog(String username, String blogId) {
-        throw new Error("Not implemented yet");
+        BlogSubscription subscription = commandRepository.findByUserIdAndBlogId(username, blogId)
+                .orElseThrow(UNSUBSCRIBED_BLOG::exception);
+        commandRepository.deleteById(subscription.getId());
     }
 }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -38,10 +38,12 @@ public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, 
     }
 
     @Override
-    public void unsubscribeBlog(String userId, String blogId) {
+    public SubscriptionStats unsubscribeBlog(String userId, String blogId) {
         BlogSubscription subscription = commandRepository.findByUserIdAndBlogId(userId, blogId)
                 .orElseThrow(UNSUBSCRIBED_BLOG::exception);
         commandRepository.deleteById(subscription.getId());
+
+        return subscriptionStats(userId, blogId);
     }
 
     private SubscriptionStats subscriptionStats(String userId, String blogId) {

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/subscription/BlogUnsubscriptionUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/subscription/BlogUnsubscriptionUseCase.java
@@ -3,5 +3,5 @@ package nettee.blolet.blog.application.usecase.subscription;
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
 
 public interface BlogUnsubscriptionUseCase {
-    SubscriptionStats unsubscribeBlog(String username, String blogId);
+    SubscriptionStats unsubscribeBlog(String userId, String blogId);
 }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/subscription/BlogUnsubscriptionUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/subscription/BlogUnsubscriptionUseCase.java
@@ -1,5 +1,7 @@
 package nettee.blolet.blog.application.usecase.subscription;
 
+import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
+
 public interface BlogUnsubscriptionUseCase {
-    void unsubscribeBlog(String username, String blogId);
+    SubscriptionStats unsubscribeBlog(String username, String blogId);
 }

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
@@ -6,15 +6,19 @@ import io.kotest.matchers.*
 import io.mockk.*
 import nettee.blolet.blog.application.port.BlogSubscriptionCommandRepositoryPort
 import nettee.blolet.blog.application.usecase.subscription.BlogSubscriptionUseCase
+import nettee.blolet.blog.application.usecase.subscription.BlogUnsubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats
 import nettee.blolet.blog.domain.BlogSubscription
 import nettee.blolet.blog.exception.BlogErrorCode.*
 import nettee.common.CustomException
+import java.time.Instant
+import java.util.*
 
 class BlogSubscriptionCommandServiceTest : FreeSpec({
 
     val commandPort = mockk<BlogSubscriptionCommandRepositoryPort>()
     val service: BlogSubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
+    val unsubscriptionUseCase: BlogUnsubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
 
     beforeTest {
         clearMocks(commandPort, answers = true, recordedCalls = true)
@@ -80,6 +84,51 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
                 commandPort.countByUserId(any())
                 commandPort.countByBlogId(any())
             }
+        }
+    }
+
+    "[UNSUBSCRIBE] 블로그 구독 취소 시" - {
+        val username = "user1"
+        val blogId = "blog-123"
+        val subscriptionId = "sub-1"
+        val now = Instant.now()
+        val subscription = BlogSubscription.builder()
+            .id(subscriptionId)
+            .userId(username)
+            .blogId(blogId)
+            .emailAllowed(false)
+            .notificationAllowed(false)
+            .createdAt(now)
+            .updatedAt(now)
+            .build()
+
+        "✅ 기존 구독이 존재하면 취소할 수 있다." {
+            // mock
+            every { commandPort.findByUserIdAndBlogId(username, blogId) } returns Optional.of(subscription)
+            every { commandPort.deleteById(subscriptionId) } just Runs
+
+            // action
+            unsubscriptionUseCase.unsubscribeBlog(username, blogId)
+
+            // verify 호출 순서 및 삭제
+            verifySequence {
+                commandPort.findByUserIdAndBlogId(username, blogId)
+                commandPort.deleteById(subscriptionId)
+            }
+        }
+
+        "🚧 구독이 존재하지 않으면 예외가 발생한다." {
+            // mock: 구독 없음
+            every { commandPort.findByUserIdAndBlogId(username, blogId) } returns Optional.empty()
+
+            // action & assert
+            val ex = shouldThrow<CustomException> {
+                unsubscriptionUseCase.unsubscribeBlog(username, blogId)
+            }
+            ex.errorCode shouldBe UNSUBSCRIBED_BLOG
+
+            // 삭제 호출 없어야 함
+            verify(inverse = true) { commandPort.deleteById(any()) }
         }
     }
 })

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
@@ -88,13 +88,13 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
     }
 
     "[UNSUBSCRIBE] 블로그 구독 취소 시" - {
-        val username = "user1"
+        val userId = "user1"
         val blogId = "blog-123"
         val subscriptionId = "sub-1"
         val now = Instant.now()
         val subscription = BlogSubscription.builder()
             .id(subscriptionId)
-            .userId(username)
+            .userId(userId)
             .blogId(blogId)
             .emailAllowed(false)
             .notificationAllowed(false)
@@ -102,28 +102,36 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
             .updatedAt(now)
             .build()
 
-        "✅ 기존 구독이 존재하면 취소할 수 있다." {
-            // mock
-            every { commandPort.findByUserIdAndBlogId(username, blogId) } returns Optional.of(subscription)
-            every { commandPort.deleteById(subscriptionId) } just Runs
+        "✅ 기존 구독이 존재하면 취소 후 최신 구독 통계를 반환한다." {
+            // mock: 구독 조회, 삭제, 통계 조회
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) } returns Optional.of(subscription)
+            every { commandPort.deleteById(subscriptionId) } just runs
+            every { commandPort.countByUserId(userId) } returns 2
+            every { commandPort.countByBlogId(blogId) } returns 5
 
             // action
-            unsubscriptionUseCase.unsubscribeBlog(username, blogId)
+            val stats: SubscriptionStats = unsubscriptionUseCase.unsubscribeBlog(userId, blogId)
 
-            // verify 호출 순서 및 삭제
+            // assert: 반환된 통계 값
+            stats.userSubscriptionCount shouldBe 2
+            stats.blogTotalSubscriberCount shouldBe 5
+
+            // 호출 순서 검증
             verifySequence {
-                commandPort.findByUserIdAndBlogId(username, blogId)
+                commandPort.findByUserIdAndBlogId(userId, blogId)
                 commandPort.deleteById(subscriptionId)
+                commandPort.countByUserId(userId)
+                commandPort.countByBlogId(blogId)
             }
         }
 
         "🚧 구독이 존재하지 않으면 예외가 발생한다." {
             // mock: 구독 없음
-            every { commandPort.findByUserIdAndBlogId(username, blogId) } returns Optional.empty()
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) } returns Optional.empty()
 
             // action & assert
             val ex = shouldThrow<CustomException> {
-                unsubscriptionUseCase.unsubscribeBlog(username, blogId)
+                unsubscriptionUseCase.unsubscribeBlog(userId, blogId)
             }
             ex.errorCode shouldBe UNSUBSCRIBED_BLOG
 


### PR DESCRIPTION
## Issues

- Resolves #58 

## Description

- 블로그 구독을 취소합니다.
- 다음 작업의 하위 작업: #9 > #43 

<br />

## Review Points

- 간단한 작업이므로 누락된 작업, 실수 등 편하게 리뷰 부탁드립니다.

<br />

## How Has This Been Tested?

다음 항목을 테스트했습니다. (Kotest FreeSpec via ChatGPT o4-mini)

- 블로그 구독이 존재할 때 -> 구독 취소 성공
- 블로그 구독이 존재하지 않을 때 -> 예외 발생
