### PR TITLE
Draft > Application, rdb : 드래프트, 블록 수정/삭제

### DIFF
--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/DraftBlockCommandAdapter.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/DraftBlockCommandAdapter.java
@@ -18,12 +18,12 @@ import static nettee.draft.draftblock.exception.DraftBlockErrorCode.DRAFT_BLOCK_
 @Repository
 @RequiredArgsConstructor
 public class DraftBlockCommandAdapter implements DraftBlockCommandPort {
-    private final DraftBlockJpaRepository draftJpaRepository;
+    private final DraftBlockJpaRepository draftBlockJpaRepository;
     private final DraftBlockEntityMapper draftEntityMapper;
 
     @Override
     public Optional<DraftBlockDetail> findById(String id) {
-        var draft = draftJpaRepository.findById(id)
+        var draft = draftBlockJpaRepository.findById(id)
                 .orElseThrow(DRAFT_BLOCK_NOT_FOUND::exception);
         return draftEntityMapper.toOptionalDraftBlockDetail(draft);
     }
@@ -32,8 +32,8 @@ public class DraftBlockCommandAdapter implements DraftBlockCommandPort {
     public DraftBlock save(DraftBlock draft) {
         var draftEntity = draftEntityMapper.toEntity(draft);
         try{
-            var newDraftBlock = draftJpaRepository.save(draftEntity);
-            draftJpaRepository.flush();
+            var newDraftBlock = draftBlockJpaRepository.save(draftEntity);
+            draftBlockJpaRepository.flush();
             return draftEntityMapper.toDomain(newDraftBlock);
         } catch (DataAccessException e) {
             throw DEFAULT.exception(e);
@@ -42,9 +42,12 @@ public class DraftBlockCommandAdapter implements DraftBlockCommandPort {
 
     @Override
     public DraftBlock update(DraftBlock draft) {
-        var existDraftBlock = draftJpaRepository.findById(draft.getId())
+        var existDraftBlock = draftBlockJpaRepository.findById(draft.getId())
                             .orElseThrow(DRAFT_BLOCK_NOT_FOUND::exception);
-        Long longNextBlockId = Long.parseLong(draft.getNextBlockId());
+        Long longNextBlockId = null;
+        if(draft.getNextBlockId() != null && !draft.getNextBlockId().isBlank()){
+            longNextBlockId = Long.parseLong(draft.getNextBlockId());
+        }
         existDraftBlock.prepareDraftBlockEntityUpdate()
                 .content(draft.getContent())
                 .nextBlockId(longNextBlockId)
@@ -52,16 +55,16 @@ public class DraftBlockCommandAdapter implements DraftBlockCommandPort {
                 .status(DraftBlockEntityStatus.valueOf(draft.getStatus()))
                 .update();
 
-        return draftEntityMapper.toDomain(draftJpaRepository.save(existDraftBlock));
+        return draftEntityMapper.toDomain(draftBlockJpaRepository.save(existDraftBlock));
     }
 
     @Override
     public void updateStatus(String id, DraftBlockStatus draftStatus) {
-        var draft = draftJpaRepository.findById(id)
+        var draft = draftBlockJpaRepository.findById(id)
                     .orElseThrow(DRAFT_BLOCK_NOT_FOUND::exception);
         draft.prepareDraftBlockEntityStatusUpdate()
                 .status(DraftBlockEntityStatus.valueOf(draftStatus))
                 .updateStatus();
-        draftJpaRepository.save(draft);
+        draftBlockJpaRepository.save(draft);
     }
 }

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/DraftBlockCommandAdapter.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/DraftBlockCommandAdapter.java
@@ -44,13 +44,12 @@ public class DraftBlockCommandAdapter implements DraftBlockCommandPort {
     public DraftBlock update(DraftBlock draft) {
         var existDraftBlock = draftJpaRepository.findById(draft.getId())
                             .orElseThrow(DRAFT_BLOCK_NOT_FOUND::exception);
+        Long longNextBlockId = Long.parseLong(draft.getNextBlockId());
         existDraftBlock.prepareDraftBlockEntityUpdate()
-                .content(existDraftBlock.getContent())
-                .blogId(existDraftBlock.getBlogId())
-                .articleId(existDraftBlock.getArticleId())
-                .draftId(existDraftBlock.getDraftId())
-                .nextBlockId(existDraftBlock.getNextBlockId())
-                .type(existDraftBlock.getType())
+                .content(draft.getContent())
+                .nextBlockId(longNextBlockId)
+                .type(draft.getType())
+                .status(DraftBlockEntityStatus.valueOf(draft.getStatus()))
                 .update();
 
         return draftEntityMapper.toDomain(draftJpaRepository.save(existDraftBlock));

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/DraftBlockCommandAdapter.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/DraftBlockCommandAdapter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import nettee.draft.draftblock.application.port.DraftBlockCommandPort;
 import nettee.draft.draftblock.domain.DraftBlock;
 import nettee.draft.draftblock.domain.type.DraftBlockStatus;
+import nettee.draft.draftblock.driven.rdb.entity.DraftBlockEntity;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatus;
 import nettee.draft.draftblock.driven.rdb.persistence.mapper.DraftBlockEntityMapper;
 import nettee.draft.draftblock.readmodel.DraftBlockReadModels.DraftBlockDetail;
@@ -44,15 +45,12 @@ public class DraftBlockCommandAdapter implements DraftBlockCommandPort {
     public DraftBlock update(DraftBlock draft) {
         var existDraftBlock = draftBlockJpaRepository.findById(draft.getId())
                             .orElseThrow(DRAFT_BLOCK_NOT_FOUND::exception);
-        Long longNextBlockId = null;
-        if(draft.getNextBlockId() != null && !draft.getNextBlockId().isBlank()){
-            longNextBlockId = Long.parseLong(draft.getNextBlockId());
-        }
+        DraftBlockEntity converted = draftEntityMapper.toEntity(draft);
         existDraftBlock.prepareDraftBlockEntityUpdate()
-                .content(draft.getContent())
-                .nextBlockId(longNextBlockId)
-                .type(draft.getType())
-                .status(DraftBlockEntityStatus.valueOf(draft.getStatus()))
+                .content(converted.getContent())
+                .nextBlockId(converted.getNextBlockId())
+                .type(converted.getType())
+                .status(converted.getStatus())
                 .update();
 
         return draftEntityMapper.toDomain(draftBlockJpaRepository.save(existDraftBlock));

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/persistence/mapper/DraftBlockEntityMapper.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/persistence/mapper/DraftBlockEntityMapper.java
@@ -5,12 +5,14 @@ import nettee.draft.draftblock.driven.rdb.entity.DraftBlockEntity;
 import nettee.draft.draftblock.readmodel.DraftBlockReadModels.DraftBlockDetail;
 import nettee.draft.draftblock.readmodel.DraftBlockReadModels.DraftBlockSummary;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.Optional;
 
 @Mapper(componentModel = "spring")
 public interface DraftBlockEntityMapper {
     DraftBlock toDomain(DraftBlockEntity draftEntity);
+    @Mapping(target = "nextBlockId", expression = "java(parseNextBlockId(draft.getNextBlockId()))")
     DraftBlockEntity toEntity(DraftBlock draft);
     DraftBlockDetail toDraftBlockDetail(DraftBlockEntity draftEntity);
     DraftBlockSummary toDraftBlockSummary(DraftBlockEntity draftEntity);
@@ -27,4 +29,8 @@ public interface DraftBlockEntityMapper {
         return Optional.ofNullable(toDraftBlockSummary(draftEntity));
     }
 
+    default Long parseNextBlockId(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        return Long.parseLong(raw);
+    }
 }

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftCommandAdapter.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftCommandAdapter.java
@@ -48,6 +48,7 @@ public class DraftCommandAdapter implements DraftCommandPort {
                 .title(draft.getTitle())
                 .content(draft.getContent())
                 .path(draft.getPath())
+                .status(DraftEntityStatus.valueOf(draft.getStatus()))
                 .update();
 
         return draftEntityMapper.toDomain(draftJpaRepository.save(existDraft));

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftCommandAdapter.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftCommandAdapter.java
@@ -45,8 +45,9 @@ public class DraftCommandAdapter implements DraftCommandPort {
         var existDraft = draftJpaRepository.findById(draft.getId())
                             .orElseThrow(DRAFT_NOT_FOUND::exception);
         existDraft.prepareDraftEntityUpdate()
-                .title(existDraft.getTitle())
-                .content(existDraft.getContent())
+                .title(draft.getTitle())
+                .content(draft.getContent())
+                .path(draft.getPath())
                 .update();
 
         return draftEntityMapper.toDomain(draftJpaRepository.save(existDraft));

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/DraftBlockCommandApi.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/DraftBlockCommandApi.java
@@ -62,16 +62,14 @@ public class DraftBlockCommandApi {
     @PatchMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public DraftBlockCommandResponse updateDraftBlock(
-            @PathVariable("id") Long id,
+            @PathVariable("id") String id,
             @RequestBody @Valid DraftBlockUpdateCommand draftUpdateCommand
     ) {
-//        var draft = mapper.toDomain(id, draftUpdateCommand);
-//
-//        return DraftBlockCommandResponse.builder()
-//                .draftblock(draftUpdateUseCase.updateDraftBlock(draft))
-//                .build();
+        var draft = mapper.toDomain(id, draftUpdateCommand);
 
-        return null;
+        return DraftBlockCommandResponse.builder()
+                .draftblock(draftUpdateUseCase.updateDraftBlock(draft))
+                .build();
     }
 
     @Operation(summary = "블록 삭제", description = "블록을 삭제합니다.")
@@ -80,8 +78,8 @@ public class DraftBlockCommandApi {
     })
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteBoard(@PathVariable("id") Long id) {
-//        draftDeleteUseCase.deleteDraftBlock(id);
+    public void deleteBoard(@PathVariable("id") String id) {
+        draftDeleteUseCase.deleteDraftBlock(id);
     }
 
 }

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/DraftBlockCommandApi.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/DraftBlockCommandApi.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -59,7 +60,7 @@ public class DraftBlockCommandApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공")
     })
-    @PatchMapping("/{id}")
+    @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public DraftBlockCommandResponse updateDraftBlock(
             @PathVariable("id") String id,

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/dto/DraftBlockCommandDto.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/dto/DraftBlockCommandDto.java
@@ -34,8 +34,6 @@ public final class DraftBlockCommandDto {
 
     @Builder
     public record DraftBlockUpdateCommand(
-            @NotNull(message = "id를 입력하십시오.")
-            String id,
             String nextBlockId, // 순서/블록 연결성 변경시 사용
             @NotBlank(message = "블록 종류를 입력하십시오.")
             String type,

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/mapper/DraftBlockDtoMapper.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/draftblock/driving/web/mapper/DraftBlockDtoMapper.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 @Mapper(componentModel = "spring")
 public interface DraftBlockDtoMapper {
     DraftBlock toDomain(DraftBlockCreateCommand command);
-    DraftBlock toDomain(Long id, DraftBlockUpdateCommand command);
+    DraftBlock toDomain(String id, DraftBlockUpdateCommand command);
     DraftBlockDetailResponse toDtoDetail(Optional<DraftBlockDetail> board);
 }

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCommandApi.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCommandApi.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -57,7 +58,7 @@ public class DraftCommandApi {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공")
     })
-    @PatchMapping("/{id}")
+    @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public DraftCommandResponse updateDraft(
             @PathVariable("id") String id,

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCommandApi.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCommandApi.java
@@ -60,15 +60,14 @@ public class DraftCommandApi {
     @PatchMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public DraftCommandResponse updateDraft(
-            @PathVariable("id") Long id,
+            @PathVariable("id") String id,
             @RequestBody @Valid DraftUpdateCommand draftUpdateCommand
     ) {
-//        var draft = mapper.toDomain(id, draftUpdateCommand);
-//
-//        return DraftCommandResponse.builder()
-//                .draft(draftUpdateUseCase.updateDraft(draft))
-//                .build();
-        return null;
+        var draft = mapper.toDomain(id, draftUpdateCommand);
+
+        return DraftCommandResponse.builder()
+                .draft(draftUpdateUseCase.updateDraft(draft))
+                .build();
     }
 
     @Operation(summary = "임시 아티클 삭제", description = "임시아티클 ID로 임시 아티클을 삭제합니다.")
@@ -77,8 +76,8 @@ public class DraftCommandApi {
     })
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteBoard(@PathVariable("id") Long id) {
-//        draftDeleteUseCase.deleteDraft(id);
+    public void deleteBoard(@PathVariable("id") String id) {
+        draftDeleteUseCase.deleteDraft(id);
     }
 
 }

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/dto/DraftCommandDto.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/dto/DraftCommandDto.java
@@ -29,8 +29,6 @@ public final class DraftCommandDto {
 
     @Builder
     public record DraftUpdateCommand(
-            @NotNull(message = "id를 입력하십시오.")
-            String id,
             @NotBlank(message = "제목을 입력하십시오.")
             @Size(min = 3, message = "제목은 세 글자 이상 입력하세요.")
             String title,

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/dto/DraftCommandDto.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/dto/DraftCommandDto.java
@@ -44,33 +44,6 @@ public final class DraftCommandDto {
     }
 
     @Builder
-    public record DraftUpdateTotalViewsCommand(
-            @NotNull(message = "id를 입력하십시오.")
-            String id,
-            @NotNull(message = "총 조회수를 입력해주세요.")
-            Integer totalViews
-    ) {
-    }
-
-    @Builder
-    public record DraftUpdateTotalLikesCommand(
-            @NotNull(message = "id를 입력하십시오.")
-            String id,
-            @NotNull(message = "총 좋아요 수를 입력해주세요.")
-            Integer totalLikes
-    ) {
-    }
-
-    @Builder
-    public record DraftUpdateTotalSharesCommand(
-            @NotNull(message = "id를 입력하십시오.")
-            String id,
-            @NotNull(message = "총 공유수를 입력해주세요.")
-            Integer totalShares
-    ) {
-    }
-
-    @Builder
     public record DraftCommandResponse(
             Draft draft
     ) {

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/mapper/DraftDtoMapper.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/mapper/DraftDtoMapper.java
@@ -4,9 +4,6 @@ import nettee.draft.domain.Draft;
 import nettee.draft.readmodel.DraftReadModels.DraftDetail;
 import nettee.draft.driving.web.dto.DraftCommandDto.DraftCreateCommand;
 import nettee.draft.driving.web.dto.DraftCommandDto.DraftUpdateCommand;
-import nettee.draft.driving.web.dto.DraftCommandDto.DraftUpdateTotalLikesCommand;
-import nettee.draft.driving.web.dto.DraftCommandDto.DraftUpdateTotalSharesCommand;
-import nettee.draft.driving.web.dto.DraftCommandDto.DraftUpdateTotalViewsCommand;
 import nettee.draft.driving.web.dto.DraftQueryDto.DraftDetailResponse;
 import org.mapstruct.Mapper;
 
@@ -15,9 +12,6 @@ import java.util.Optional;
 @Mapper(componentModel = "spring")
 public interface DraftDtoMapper {
     Draft toDomain(DraftCreateCommand command);
-    Draft toDomain(Long id, DraftUpdateCommand command);
-    Draft toDomain(Long id, DraftUpdateTotalSharesCommand command);
-    Draft toDomain(Long id, DraftUpdateTotalLikesCommand command);
-    Draft toDomain(Long id, DraftUpdateTotalViewsCommand command);
+    Draft toDomain(String id, DraftUpdateCommand command);
     DraftDetailResponse toDtoDetail(Optional<DraftDetail> board);
 }


### PR DESCRIPTION
## Issues

- Resolves #72
- Resolves #73 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 목록으로 작성합니다. PR 병합 시 목록의 이슈들이 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->


## Description
기존에 이미 추가해 놓은 코드들이 있어, 짧게 PR을 만들지 못했습니다. 양해 부탁드립니다.

- 임시아티클(Draft) 수정/삭제 기능을 추가하였습니다.
  - 임시 아티클 수정 기능을 추가하였습니다.(PUT)
  - 임시 아티클 삭제 기능을 추가하였습니다.(DELETE)
<br />  
- 블록(DraftBlock) 수정/삭제 기능을 추가하였습니다.
  - 블록 수정 기능을 추가하였습니다.(PUT)
  - 블록 삭제 기능을 추가하였습니다.(DELETE)
<br />

## Review Points
DraftBlock CommandAdapter에 nextBlockId가 들어오지 않을 것을 대비해서 null guard를 해놓았는데, 
이런식으로 처리를 하면 되는 건지 아니면 더 깔끔하게 처리하는 방법들이 있는지 궁금합니다.

```
Long longNextBlockId = null;
if(draft.getNextBlockId() != null && !draft.getNextBlockId().isBlank()){
    longNextBlockId = Long.parseLong(draft.getNextBlockId());
}
existDraftBlock.prepareDraftBlockEntityUpdate()
        .content(draft.getContent())
        .nextBlockId(longNextBlockId)
        .type(draft.getType())
        .status(DraftBlockEntityStatus.valueOf(draft.getStatus()))
        .update();
```

update쪽에서는 이렇게 null인 경우에는 기존의 것으로 하게 해두었습니다.
```
this.nextBlockId = (nextBlockId != null) ? nextBlockId : this.nextBlockId;
```


<!-- 리뷰어가 중점적으로 확인할 항목을 작성해 주세요. -->
<!-- (Ex: 구현 로직, API 스펙, 테스트 케이스 등) -->


<br />

## How Has This Been Tested?

- Postman으로 테스트하여 확인하였습니다.

<!-- 테스트를 생략하거나, 실행하여 육안으로 확인했다고 쓸 수도 있습니다. -->

<br />

## Additional Notes