### PR TITLE
Blog > Application: 뉴스레터 구독 UseCase, Service 구현

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogSubscriptionCommandRepositoryPort.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogSubscriptionCommandRepositoryPort.java
@@ -9,6 +9,8 @@ public interface BlogSubscriptionCommandRepositoryPort {
 
     BlogSubscription save(BlogSubscription blog);
 
+    BlogSubscription update(BlogSubscription blog);
+
     void deleteById(String id);
 
     Optional<BlogSubscription> findByUserIdAndBlogId(String userId, String blogId);

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -58,7 +58,7 @@ public class BlogSubscriptionCommandService
                 .orElseThrow(UNSUBSCRIBED_BLOG::exception);
 
         // Exception: 이미 뉴스레터를 구독 중
-        if (blogSubscription.getNotificationAllowed()) {
+        if (blogSubscription.getEmailAllowed()) {
             throw ALREADY_SUBSCRIBED_BLOG_NEWSLETTER.exception();
         }
 

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -2,6 +2,7 @@ package nettee.blolet.blog.application.service;
 
 import lombok.RequiredArgsConstructor;
 import nettee.blolet.blog.application.port.BlogSubscriptionCommandRepositoryPort;
+import nettee.blolet.blog.application.usecase.newsletter.BlogNewsletterSubscriptionUseCase;
 import nettee.blolet.blog.application.usecase.subscription.BlogSubscriptionUseCase;
 import nettee.blolet.blog.application.usecase.subscription.BlogUnsubscriptionUseCase;
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
@@ -9,11 +10,15 @@ import nettee.blolet.blog.domain.BlogSubscription;
 import org.springframework.stereotype.Service;
 
 import static nettee.blolet.blog.exception.BlogErrorCode.ALREADY_SUBSCRIBED_BLOG;
+import static nettee.blolet.blog.exception.BlogErrorCode.ALREADY_SUBSCRIBED_BLOG_NEWSLETTER;
 import static nettee.blolet.blog.exception.BlogErrorCode.UNSUBSCRIBED_BLOG;
 
 @Service
 @RequiredArgsConstructor
-public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, BlogUnsubscriptionUseCase {
+public class BlogSubscriptionCommandService
+        implements BlogSubscriptionUseCase,
+        BlogUnsubscriptionUseCase,
+        BlogNewsletterSubscriptionUseCase {
 
     private final BlogSubscriptionCommandRepositoryPort commandRepository;
 
@@ -42,6 +47,23 @@ public class BlogSubscriptionCommandService implements BlogSubscriptionUseCase, 
         BlogSubscription subscription = commandRepository.findByUserIdAndBlogId(userId, blogId)
                 .orElseThrow(UNSUBSCRIBED_BLOG::exception);
         commandRepository.deleteById(subscription.getId());
+
+        return subscriptionStats(userId, blogId);
+    }
+
+    @Override
+    public SubscriptionStats subscribeBlogNewsletter(String userId, String blogId) {
+        // Prerequisite: 블로그를 구독 중이어야 뉴스레터를 구독할 수 있음.
+        BlogSubscription blogSubscription = commandRepository.findByUserIdAndBlogId(userId, blogId)
+                .orElseThrow(UNSUBSCRIBED_BLOG::exception);
+
+        // Exception: 이미 뉴스레터를 구독 중
+        if (blogSubscription.getNotificationAllowed()) {
+            throw ALREADY_SUBSCRIBED_BLOG_NEWSLETTER.exception();
+        }
+
+        blogSubscription.subscribeNewsletter();
+        commandRepository.update(blogSubscription);
 
         return subscriptionStats(userId, blogId);
     }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/newsletter/BlogNewsletterSubscriptionUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/newsletter/BlogNewsletterSubscriptionUseCase.java
@@ -1,5 +1,7 @@
 package nettee.blolet.blog.application.usecase.newsletter;
 
+import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
+
 public interface BlogNewsletterSubscriptionUseCase {
-    void subscribeBlogNewsletter(String username, String blogId);
+    SubscriptionStats subscribeBlogNewsletter(String userId, String blogId);
 }

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.*
 import io.mockk.*
 import nettee.blolet.blog.application.port.BlogSubscriptionCommandRepositoryPort
+import nettee.blolet.blog.application.usecase.newsletter.BlogNewsletterSubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.BlogSubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.BlogUnsubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats
@@ -19,6 +20,7 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
     val commandPort = mockk<BlogSubscriptionCommandRepositoryPort>()
     val service: BlogSubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
     val unsubscriptionUseCase: BlogUnsubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
+    val newsletterSubscriptionUseCase: BlogNewsletterSubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
 
     beforeTest {
         clearMocks(commandPort, answers = true, recordedCalls = true)
@@ -137,6 +139,91 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
 
             // 삭제 호출 없어야 함
             verify(inverse = true) { commandPort.deleteById(any()) }
+        }
+    }
+
+    "[subscribeBlogNewsletter] 뉴스레터 구독 로직" - {
+        val userId = "USER-1"
+        val blogId = "BLOG-1"
+        val now = Instant.now()
+
+        // 이미 블로그 구독 중인 엔티티 (notificationAllowed = false)
+        val originalSubscription = BlogSubscription.builder()
+            .id("SUB-1")
+            .userId(userId)
+            .blogId(blogId)
+            .emailAllowed(false)
+            .notificationAllowed(false)
+            .createdAt(now)
+            .build()
+
+        // update() 호출 시 캡처용 리스트
+        val captured = mutableListOf<BlogSubscription>()
+
+        beforeTest {
+            // 기본 성공 플로우 모의 설정
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) } returns Optional.of(originalSubscription)
+            every { commandPort.update(capture(captured)) } answers { firstArg<BlogSubscription>() }
+            every { commandPort.countByUserId(userId) } returns 3
+            every { commandPort.countByBlogId(blogId) } returns 7
+        }
+
+        "✅ 구독 중인 블로그에 한해 뉴스레터 구독이 가능하다" {
+            val stats: SubscriptionStats = newsletterSubscriptionUseCase.subscribeBlogNewsletter(userId, blogId)
+
+            // 결과 검증
+            stats.userSubscriptionCount shouldBe 3
+            stats.blogTotalSubscriberCount shouldBe 7
+
+            // 실제로 emailAllowed가 true로 변경됐는지 확인
+            captured.single().emailAllowed shouldBe true
+
+            // 호출 순서 검증
+
+            // update() 호출 뒤에 countByUserId()가 언젠간 호출됐음을 검증
+            verifyOrder { // ≠ verifySequence
+                commandPort.update(any())
+                commandPort.countByUserId(userId)
+            }
+
+            // update() 호출 뒤에 countByBlogId()가 언젠간 호출됐음을 검증
+            verifyOrder {
+                commandPort.update(any())
+                commandPort.countByBlogId(blogId)
+            }
+        }
+
+        "🚧 구독하지 않은 블로그에선 예외가 발생한다" {
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) } returns Optional.empty()
+
+            val exc = shouldThrow<CustomException> {
+                newsletterSubscriptionUseCase.subscribeBlogNewsletter(userId, blogId)
+            }
+            exc.errorCode shouldBe UNSUBSCRIBED_BLOG
+
+            // update는 호출되지 않아야 함
+            verify(exactly = 0) { commandPort.update(any()) }
+        }
+
+        "🚧 이미 뉴스레터를 구독 중이면 예외가 발생한다" {
+            // notificationAllowed = true인 경우
+            val already = BlogSubscription.builder()
+                .id("SUB-1")
+                .userId(userId)
+                .blogId(blogId)
+                .emailAllowed(false)
+                .notificationAllowed(true)
+                .createdAt(now)
+                .build()
+
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) } returns Optional.of(already)
+
+            val exc = shouldThrow<CustomException> {
+                newsletterSubscriptionUseCase.subscribeBlogNewsletter(userId, blogId)
+            }
+            exc.errorCode shouldBe ALREADY_SUBSCRIBED_BLOG_NEWSLETTER
+
+            verify(exactly = 0) { commandPort.update(any()) }
         }
     }
 })

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
@@ -211,8 +211,8 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
                 .id("SUB-1")
                 .userId(userId)
                 .blogId(blogId)
-                .emailAllowed(false)
-                .notificationAllowed(true)
+                .emailAllowed(true)
+                .notificationAllowed(false)
                 .createdAt(now)
                 .build()
 


### PR DESCRIPTION
## Issues

- Resolves #59 

## Description

- 뉴스레터 구독을 구현했습니다.
- 블로그 구독 중 '이메일 동의'를 뉴스레터 구독으로 보았습니다.

<br />

## Review Points

- 서비스 로직 위주로 살펴봐 주세요.

<br />

## How Has This Been Tested?

- 테스트 케이스
  - ✅ 구독 중인 블로그에 한해 뉴스레터 구독이 가능하다
  - 🚧 구독하지 않은 블로그에선 예외가 발생한다
  - 🚧 이미 뉴스레터를 구독 중이면 예외가 발생한다

<br />

## Additional Notes

- 우선 블로그 구독 중에만 뉴스레터 구독이 가능하다는 콘셉트로 개발했습니다.
- 아직 관련 PRD가 작성되지는 않은 것 같습니다.
