### PR TITLE
Blog > Application: 뉴스레터 구독 취소 (수신 비동의)

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogSubscriptionCommandService.java
@@ -3,6 +3,7 @@ package nettee.blolet.blog.application.service;
 import lombok.RequiredArgsConstructor;
 import nettee.blolet.blog.application.port.BlogSubscriptionCommandRepositoryPort;
 import nettee.blolet.blog.application.usecase.newsletter.BlogNewsletterSubscriptionUseCase;
+import nettee.blolet.blog.application.usecase.newsletter.BlogNewsletterUnsubscriptionUseCase;
 import nettee.blolet.blog.application.usecase.subscription.BlogSubscriptionUseCase;
 import nettee.blolet.blog.application.usecase.subscription.BlogUnsubscriptionUseCase;
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
@@ -12,13 +13,15 @@ import org.springframework.stereotype.Service;
 import static nettee.blolet.blog.exception.BlogErrorCode.ALREADY_SUBSCRIBED_BLOG;
 import static nettee.blolet.blog.exception.BlogErrorCode.ALREADY_SUBSCRIBED_BLOG_NEWSLETTER;
 import static nettee.blolet.blog.exception.BlogErrorCode.UNSUBSCRIBED_BLOG;
+import static nettee.blolet.blog.exception.BlogErrorCode.UNSUBSCRIBED_BLOG_NEWSLETTER;
 
 @Service
 @RequiredArgsConstructor
 public class BlogSubscriptionCommandService
         implements BlogSubscriptionUseCase,
         BlogUnsubscriptionUseCase,
-        BlogNewsletterSubscriptionUseCase {
+        BlogNewsletterSubscriptionUseCase,
+        BlogNewsletterUnsubscriptionUseCase {
 
     private final BlogSubscriptionCommandRepositoryPort commandRepository;
 
@@ -63,6 +66,23 @@ public class BlogSubscriptionCommandService
         }
 
         blogSubscription.subscribeNewsletter();
+        commandRepository.update(blogSubscription);
+
+        return subscriptionStats(userId, blogId);
+    }
+
+    @Override
+    public SubscriptionStats unsubscribeBlogNewsletter(String userId, String blogId) {
+        // Prerequisite: 이미 블로그가 구독취소되어 있다면 뉴스레터도 취소된 것으로 취급됨.
+        BlogSubscription blogSubscription = commandRepository.findByUserIdAndBlogId(userId, blogId)
+                .orElseThrow(UNSUBSCRIBED_BLOG::exception);
+
+        // Exception: 이미 뉴스레터 구독 취소
+        if (!blogSubscription.getEmailAllowed()) {
+            throw UNSUBSCRIBED_BLOG_NEWSLETTER.exception();
+        }
+
+        blogSubscription.unsubscribeNewsletter();
         commandRepository.update(blogSubscription);
 
         return subscriptionStats(userId, blogId);

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/newsletter/BlogNewsletterUnsubscriptionUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/newsletter/BlogNewsletterUnsubscriptionUseCase.java
@@ -1,5 +1,7 @@
 package nettee.blolet.blog.application.usecase.newsletter;
 
+import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
+
 public interface BlogNewsletterUnsubscriptionUseCase {
-    void unsubscribeBlogNewsletter(String username, String blogId);
+    SubscriptionStats unsubscribeBlogNewsletter(String userId, String blogId);
 }

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.*
 import io.mockk.*
 import nettee.blolet.blog.application.port.BlogSubscriptionCommandRepositoryPort
 import nettee.blolet.blog.application.usecase.newsletter.BlogNewsletterSubscriptionUseCase
+import nettee.blolet.blog.application.usecase.newsletter.BlogNewsletterUnsubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.BlogSubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.BlogUnsubscriptionUseCase
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats
@@ -21,6 +22,7 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
     val service: BlogSubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
     val unsubscriptionUseCase: BlogUnsubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
     val newsletterSubscriptionUseCase: BlogNewsletterSubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
+    val newsletterUnsubscriptionUseCase: BlogNewsletterUnsubscriptionUseCase = BlogSubscriptionCommandService(commandPort)
 
     beforeTest {
         clearMocks(commandPort, answers = true, recordedCalls = true)
@@ -224,6 +226,83 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
             exc.errorCode shouldBe ALREADY_SUBSCRIBED_BLOG_NEWSLETTER
 
             verify(exactly = 0) { commandPort.update(any()) }
+        }
+    }
+
+    "[unsubscribeBlogNewsletter] 뉴스레터 구독 취소 로직" - {
+        val userId = "USER-1"
+        val blogId = "BLOG-1"
+        val now = Instant.now()
+
+        val captured = mutableListOf<BlogSubscription>()
+
+        "🚧 구독 자체가 없는 경우에는 UNSUBSCRIBED_BLOG 예외가 발생한다" {
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) } returns Optional.empty()
+
+            val ex = shouldThrow<CustomException> {
+                newsletterUnsubscriptionUseCase.unsubscribeBlogNewsletter(userId, blogId)
+            }
+            ex.errorCode shouldBe UNSUBSCRIBED_BLOG
+            verify(inverse = true) { commandPort.update(any()) }
+        }
+
+        "🚧 이미 뉴스레터 구독이 해제된 경우에는 UNSUBSCRIBED_BLOG_NEWSLETTER 예외가 발생한다" {
+            // notificationAllowed = false 인 경우
+            val alreadyUnsubscribed = BlogSubscription.builder()
+                .id("SUB-1")
+                .userId(userId)
+                .blogId(blogId)
+                .emailAllowed(true)
+                .notificationAllowed(false)
+                .createdAt(now)
+                .build()
+
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) }
+                .returns(Optional.of(alreadyUnsubscribed))
+
+            val ex = shouldThrow<CustomException> {
+                newsletterUnsubscriptionUseCase.unsubscribeBlogNewsletter(userId, blogId)
+            }
+            ex.errorCode shouldBe UNSUBSCRIBED_BLOG_NEWSLETTER
+            verify(inverse = true) { commandPort.update(any()) }
+        }
+
+        "✅ 정상적으로 뉴스레터 구독을 취소하고 통계가 리턴된다" {
+            // notificationAllowed = true 인 원본 생성
+            val original = BlogSubscription.builder()
+                .id("SUB-2")
+                .userId(userId)
+                .blogId(blogId)
+                .emailAllowed(true)
+                .notificationAllowed(true)
+                .createdAt(now)
+                .build()
+
+            every { commandPort.findByUserIdAndBlogId(userId, blogId) }
+                .returns(Optional.of(original))
+            every { commandPort.update(capture(captured)) }
+                .answers { firstArg<BlogSubscription>() }
+            every { commandPort.countByUserId(userId) } returns 4
+            every { commandPort.countByBlogId(blogId) } returns 7
+
+            val stats: SubscriptionStats = newsletterUnsubscriptionUseCase.unsubscribeBlogNewsletter(userId, blogId)
+
+            // 상태 검증
+            stats.userSubscriptionCount shouldBe 4
+            stats.blogTotalSubscriberCount shouldBe 7
+
+            // 호출 순서 검증 (update 이후 count 호출 순서는 고정, countByUserId와 countByBlogId 사이 순서는 무관)
+            verifyOrder { // ≠ verifySequence
+                commandPort.update(any())
+                commandPort.countByUserId(userId)
+            }
+            verifyOrder {
+                commandPort.update(any())
+                commandPort.countByBlogId(blogId)
+            }
+
+            // 캡처된 객체의 newsletter 상태가 false 로 변경되었는지 검증
+            captured.first().emailAllowed shouldBe false
         }
     }
 })

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogSubscriptionCommandServiceTest.kt
@@ -247,12 +247,12 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
         }
 
         "🚧 이미 뉴스레터 구독이 해제된 경우에는 UNSUBSCRIBED_BLOG_NEWSLETTER 예외가 발생한다" {
-            // notificationAllowed = false 인 경우
+            // emailAllowed = false 인 경우
             val alreadyUnsubscribed = BlogSubscription.builder()
                 .id("SUB-1")
                 .userId(userId)
                 .blogId(blogId)
-                .emailAllowed(true)
+                .emailAllowed(false)
                 .notificationAllowed(false)
                 .createdAt(now)
                 .build()
@@ -268,13 +268,13 @@ class BlogSubscriptionCommandServiceTest : FreeSpec({
         }
 
         "✅ 정상적으로 뉴스레터 구독을 취소하고 통계가 리턴된다" {
-            // notificationAllowed = true 인 원본 생성
+            // emailAllowed = true 인 원본 생성
             val original = BlogSubscription.builder()
                 .id("SUB-2")
                 .userId(userId)
                 .blogId(blogId)
                 .emailAllowed(true)
-                .notificationAllowed(true)
+                .notificationAllowed(false)
                 .createdAt(now)
                 .build()
 


### PR DESCRIPTION
<br />

<table align="center" border>
<tr height="45">
  <td>🏗️ Draft 상태입니다. 앞선 작업 병합 후 Rebase하여 오픈합니다.</td>
</tr>
</table>

## Issues

- Resolves #60 

## Description

- 뉴스레터 구독 취소 서비스 구현입니다.

<br />

## Review Points

_No Response_

<br />

## How Has This Been Tested?

- Test cases
  - 🚧 구독 자체가 없는 경우에는 `UNSUBSCRIBED_BLOG` 예외가 발생한다.
  - 🚧 이미 뉴스레터 구독이 해제된 경우에는 `UNSUBSCRIBED_BLOG_NEWSLETTER` 예외가 발생한다.
  - ✅ 정상적으로 뉴스레터 구독을 취소하고 통계가 리턴된다.
