### PR TITLE
☀️ Common: 유효성 체크를 직접 관리하기 위한 Preconditions 유틸리티 추가

### DIFF
--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -1,0 +1,64 @@
+package nettee.common.validation;
+
+import nettee.common.ErrorCode;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public final class Preconditions {
+    private Preconditions() {}
+
+    // ╭────────────────────────────╮
+    //    validateNotNull variants
+    // ╰────────────────────────────╯
+
+    public static void validateNotNull(Object value, ErrorCode errorCode) {
+        if (value == null) {
+            throw errorCode.exception();
+        }
+    }
+
+    public static void validateNotNull(Object value, ErrorCode errorCode, Throwable cause) {
+        if (value == null) {
+            throw errorCode.exception(cause);
+        }
+    }
+
+    public static void validateNotNull(Object value, ErrorCode errorCode, Runnable runnable) {
+        if (value == null) {
+            throw errorCode.exception(runnable);
+        }
+    }
+
+    public static void validateNotNull(
+            Object value,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        if (value == null) {
+            throw errorCode.exception(runnable, cause);
+        }
+    }
+
+    public static void validateNotNull(
+            Object value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        if (value == null) {
+            throw errorCode.exception(payloadSupplier);
+        }
+    }
+
+    public static void validateNotNull(
+            Object value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        if (value == null) {
+            throw errorCode.exception(payloadSupplier, cause);
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -663,6 +663,26 @@ public final class Preconditions {
         }
     }
 
+    private static void performMaxValidation(
+            Collection<?> collection,
+            int max,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        validateMaxArgument(max);
+
+        if (collection == null) {
+            return; // null은 크기 0으로 취급
+        }
+
+        if (collection.isEmpty()) {
+            return; // 항상 <= max (where max >= 0)
+        }
+
+        if (collection.size() > max) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void validateLengthArgument(String value, int min, int max) {
         assert min >= 0 : "min cannot be less than 0";
         assert max >= 0 : "max cannot be less than 0";

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -61,4 +61,66 @@ public final class Preconditions {
             throw errorCode.exception(payloadSupplier, cause);
         }
     }
+
+    // ╭─────────────────────────────────────╮
+    //    String: validateNotEmpty variants
+    // ╰─────────────────────────────────────╯
+
+    public static void validateNotEmpty(String value, ErrorCode errorCode) {
+        if (isEmpty(value)) {
+            throw errorCode.exception();
+        }
+    }
+
+    public static void validateNotEmpty(String value, ErrorCode errorCode, Throwable cause) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(cause);
+        }
+    }
+
+    public static void validateNotEmpty(String value, ErrorCode errorCode, Runnable runnable) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(runnable);
+        }
+    }
+
+    public static void validateNotEmpty(
+            String value,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(runnable, cause);
+        }
+    }
+
+    public static void validateNotEmpty(
+            String value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(payloadSupplier);
+        }
+    }
+
+    public static void validateNotEmpty(
+            String value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(payloadSupplier, cause);
+        }
+    }
+
+    // ╭──────────────────╮
+    //    Helper Methods
+    // ╰──────────────────╯
+
+    private static boolean isEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
 }

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -413,6 +413,26 @@ public final class Preconditions {
         }
     }
 
+    private static void performMaxValidation(
+            String value,
+            int max,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        validateMaxArgument(max);
+
+        if (value == null) {
+            return; // null은 길이 0으로 보고 항상 허용 (max >= 0 전제)
+        }
+
+        if (value.isEmpty()) {
+            return; // 길이 0 <= max
+        }
+
+        if (value.length() > max) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void validateLengthArgument(String value, int min, int max) {
         assert min >= 0 : "min cannot be less than 0";
         assert max >= 0 : "max cannot be less than 0";
@@ -429,5 +449,9 @@ public final class Preconditions {
         if (value == null && min != 0) {
             throw new NullPointerException("String must not be null if min is not 0.");
         }
+    }
+
+    private static void validateMaxArgument(int max) {
+        assert max >= 0 : "max cannot be less than 0";
     }
 }

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -171,6 +171,60 @@ public final class Preconditions {
         }
     }
 
+    // ╭─────────────────────────────╮
+    //    validateNotBlank variants
+    // ╰─────────────────────────────╯
+
+    public static void validateNotBlank(String value, ErrorCode errorCode) {
+        if (isBlank(value)) {
+            throw errorCode.exception();
+        }
+    }
+
+    public static void validateNotBlank(String value, ErrorCode errorCode, Throwable cause) {
+        if (isBlank(value)) {
+            throw errorCode.exception(cause);
+        }
+    }
+
+    public static void validateNotBlank(String value, ErrorCode errorCode, Runnable runnable) {
+        if (isBlank(value)) {
+            throw errorCode.exception(runnable);
+        }
+    }
+
+    public static void validateNotBlank(
+            String value,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        if (isBlank(value)) {
+            throw errorCode.exception(runnable, cause);
+        }
+    }
+
+    public static void validateNotBlank(
+            String value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        if (isBlank(value)) {
+            throw errorCode.exception(payloadSupplier);
+        }
+    }
+
+    public static void validateNotBlank(
+            String value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        if (isBlank(value)) {
+            throw errorCode.exception(payloadSupplier, cause);
+        }
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯
@@ -181,5 +235,9 @@ public final class Preconditions {
 
     private static boolean isEmpty(Collection<?> value) {
         return value == null || value.isEmpty();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -290,6 +290,71 @@ public final class Preconditions {
         performLengthValidation(value, min, max, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭───────────────────────────────────────╮
+    //    collection: validateLength variants
+    // ╰───────────────────────────────────────╯
+
+    public static void validateLength(
+            Collection<?> collection,
+            int min,
+            int max,
+            ErrorCode errorCode
+    ) {
+        performLengthValidation(collection, min, max, errorCode::exception);
+    }
+
+    public static void validateLength(
+            Collection<?> collection,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performLengthValidation(collection, min, max, () -> errorCode.exception(cause));
+    }
+
+    public static void validateLength(
+            Collection<?> collection,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performLengthValidation(collection, min, max, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateLength(
+            Collection<?> collection,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performLengthValidation(collection, min, max, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateLength(
+            Collection<?> collection,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performLengthValidation(collection, min, max, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateLength(
+            Collection<?> collection,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performLengthValidation(collection, min, max, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭────────────────────────────────╮
     //    String: validateMin variants
     // ╰────────────────────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -349,6 +349,65 @@ public final class Preconditions {
         performMinValidation(value, min, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭────────────────────────────────╮
+    //    String: validateMax variants
+    // ╰────────────────────────────────╯
+
+    public static void validateMax(
+            String value,
+            int max,
+            ErrorCode errorCode
+    ) {
+        performMaxValidation(value, max, errorCode::exception);
+    }
+
+    public static void validateMax(
+            String value,
+            int max,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performMaxValidation(value, max, () -> errorCode.exception(cause));
+    }
+
+    public static void validateMax(
+            String value,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performMaxValidation(value, max, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateMax(
+            String value,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performMaxValidation(value, max, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateMax(
+            String value,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performMaxValidation(value, max, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateMax(
+            String value,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performMaxValidation(value, max, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -561,6 +561,29 @@ public final class Preconditions {
         }
     }
 
+    private static void performMinValidation(
+            Collection<?> collection,
+            int min,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        validateMinArgument(collection, min);
+
+        if (collection == null) {
+            if (min == 0) {
+                return; // 허용: min이 0이면 null도 OK
+            }
+            throw new NullPointerException("Collection must not be null if min is not 0.");
+        }
+
+        if (collection.isEmpty() && min == 0) {
+            return; // 빈 컬렉션도 min == 0이면 허용
+        }
+
+        if (collection.size() < min) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void performMaxValidation(
             String value,
             int max,
@@ -605,6 +628,14 @@ public final class Preconditions {
 
         if (value == null && min != 0) {
             throw new NullPointerException("String must not be null if min is not 0.");
+        }
+    }
+
+    private static void validateMinArgument(Collection<?> collection, int min) {
+        assert min >= 0 : "min cannot be less than 0";
+
+        if (collection == null && min != 0) {
+            throw new NullPointerException("Collection must not be null if min is not 0.");
         }
     }
 

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -593,6 +593,65 @@ public final class Preconditions {
         performMaxValidation(collection, max, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭──────────────────────────────────╮
+    //    String: validateRegex variants
+    // ╰──────────────────────────────────╯
+
+    public static void validateRegex(
+            String value,
+            String regex,
+            ErrorCode errorCode
+    ) {
+        performRegexValidation(value, regex, errorCode::exception);
+    }
+
+    public static void validateRegex(
+            String value,
+            String regex,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performRegexValidation(value, regex, () -> errorCode.exception(cause));
+    }
+
+    public static void validateRegex(
+            String value,
+            String regex,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performRegexValidation(value, regex, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateRegex(
+            String value,
+            String regex,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performRegexValidation(value, regex, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateRegex(
+            String value,
+            String regex,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performRegexValidation(value, regex, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateRegex(
+            String value,
+            String regex,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performRegexValidation(value, regex, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -2,6 +2,7 @@ package nettee.common.validation;
 
 import nettee.common.ErrorCode;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -116,11 +117,69 @@ public final class Preconditions {
         }
     }
 
+    // ╭─────────────────────────────────────────╮
+    //    Collection: validateNotEmpty variants
+    // ╰─────────────────────────────────────────╯
+
+    public static void validateNotEmpty(Collection<?> value, ErrorCode errorCode) {
+        if (isEmpty(value)) {
+            throw errorCode.exception();
+        }
+    }
+
+    public static void validateNotEmpty(Collection<?> value, ErrorCode errorCode, Throwable cause) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(cause);
+        }
+    }
+
+    public static void validateNotEmpty(Collection<?> value, ErrorCode errorCode, Runnable runnable) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(runnable);
+        }
+    }
+
+    public static void validateNotEmpty(
+            Collection<?> value,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(runnable, cause);
+        }
+    }
+
+    public static void validateNotEmpty(
+            Collection<?> value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(payloadSupplier);
+        }
+    }
+
+    public static void validateNotEmpty(
+            Collection<?> value,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        if (isEmpty(value)) {
+            throw errorCode.exception(payloadSupplier, cause);
+        }
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯
 
     private static boolean isEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    private static boolean isEmpty(Collection<?> value) {
         return value == null || value.isEmpty();
     }
 }

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -290,6 +290,65 @@ public final class Preconditions {
         performLengthValidation(value, min, max, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭────────────────────────────────╮
+    //    String: validateMin variants
+    // ╰────────────────────────────────╯
+
+    public static void validateMin(
+            String value,
+            int min,
+            ErrorCode errorCode
+    ) {
+        performMinValidation(value, min, errorCode::exception);
+    }
+
+    public static void validateMin(
+            String value,
+            int min,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performMinValidation(value, min, () -> errorCode.exception(cause));
+    }
+
+    public static void validateMin(
+            String value,
+            int min,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performMinValidation(value, min, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateMin(
+            String value,
+            int min,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performMinValidation(value, min, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateMin(
+            String value,
+            int min,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performMinValidation(value, min, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateMin(
+            String value,
+            int min,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performMinValidation(value, min, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -532,6 +532,65 @@ public final class Preconditions {
         performMaxValidation(value, max, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭────────────────────────────────────╮
+    //    collection: validateMax variants
+    // ╰────────────────────────────────────╯
+
+    public static void validateMax(
+            Collection<?> collection,
+            int max,
+            ErrorCode errorCode
+    ) {
+        performMaxValidation(collection, max, errorCode::exception);
+    }
+
+    public static void validateMax(
+            Collection<?> collection,
+            int max,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performMaxValidation(collection, max, () -> errorCode.exception(cause));
+    }
+
+    public static void validateMax(
+            Collection<?> collection,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performMaxValidation(collection, max, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateMax(
+            Collection<?> collection,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performMaxValidation(collection, max, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateMax(
+            Collection<?> collection,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performMaxValidation(collection, max, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateMax(
+            Collection<?> collection,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performMaxValidation(collection, max, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -449,6 +449,30 @@ public final class Preconditions {
         }
     }
 
+    private static void performLengthValidation(
+            Collection<?> collection,
+            int min,
+            int max,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        validateLengthArgument(collection, min, max);
+
+        if (collection == null) {
+            if (min == 0) {
+                return; // 허용: min이 0이면 null도 OK
+            }
+            throw new NullPointerException("Collection must not be null if min is not 0.");
+        }
+
+        if (collection.isEmpty() && min == 0) {
+            return;
+        }
+
+        if (collection.size() < min || collection.size() > max) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void performMinValidation(
             String value,
             int min,
@@ -499,6 +523,15 @@ public final class Preconditions {
 
         if (value == null && min != 0) {
             throw new NullPointerException("String must not be null if min is not 0.");
+        }
+    }
+
+    private static void validateLengthArgument(Collection<?> collection, int min, int max) {
+        assert min >= 0 && max >= 0 : "min, max cannot be less than or equal to 0";
+        assert min < max : "max must be greater than or equal to " + min;
+
+        if (collection == null && min != 0) {
+            throw new NullPointerException("Collection must not be null if min is not 0.");
         }
     }
 

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -414,6 +414,65 @@ public final class Preconditions {
         performMinValidation(value, min, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭────────────────────────────────────╮
+    //    collection: validateMin variants
+    // ╰────────────────────────────────────╯
+
+    public static void validateMin(
+            Collection<?> collection,
+            int min,
+            ErrorCode errorCode
+    ) {
+        performMinValidation(collection, min, errorCode::exception);
+    }
+
+    public static void validateMin(
+            Collection<?> collection,
+            int min,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performMinValidation(collection, min, () -> errorCode.exception(cause));
+    }
+
+    public static void validateMin(
+            Collection<?> collection,
+            int min,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performMinValidation(collection, min, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateMin(
+            Collection<?> collection,
+            int min,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performMinValidation(collection, min, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateMin(
+            Collection<?> collection,
+            int min,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performMinValidation(collection, min, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateMin(
+            Collection<?> collection,
+            int min,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performMinValidation(collection, min, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭────────────────────────────────╮
     //    String: validateMax variants
     // ╰────────────────────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -240,4 +240,39 @@ public final class Preconditions {
     private static boolean isBlank(String value) {
         return value == null || value.isBlank();
     }
+
+    private static void performLengthValidation(
+            String value,
+            int min,
+            int max,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        validateLengthArgument(value, min, max);
+
+        if (value == null) {
+            if (min == 0) {
+                return; // null 허용: min이 0이면
+            }
+            throw new NullPointerException("String must not be null if min is not 0.");
+        }
+
+        if (value.isEmpty() && min == 0) {
+            return; // 빈 문자열도 min == 0이면 허용
+        }
+
+        int len = value.length();
+        if (len < min || len > max) {
+            throw exceptionSupplier.get();
+        }
+    }
+
+    private static void validateLengthArgument(String value, int min, int max) {
+        assert min >= 0 : "min cannot be less than 0";
+        assert max >= 0 : "max cannot be less than 0";
+        assert min <= max : "max must be greater than or equal to " + min;
+
+        if (value == null && min != 0) {
+            throw new NullPointerException("String must not be null if min is not 0.");
+        }
+    }
 }

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -225,6 +225,71 @@ public final class Preconditions {
         }
     }
 
+    // ╭───────────────────────────────────╮
+    //    String: validateLength variants
+    // ╰───────────────────────────────────╯
+
+    public static void validateLength(
+            String value,
+            int min,
+            int max,
+            ErrorCode errorCode
+    ) {
+        performLengthValidation(value, min, max, errorCode::exception);
+    }
+
+    public static void validateLength(
+            String value,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performLengthValidation(value, min, max, () -> errorCode.exception(cause));
+    }
+
+    public static void validateLength(
+            String value,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performLengthValidation(value, min, max, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateLength(
+            String value,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performLengthValidation(value, min, max, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateLength(
+            String value,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performLengthValidation(value, min, max, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateLength(
+            String value,
+            int min,
+            int max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performLengthValidation(value, min, max, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭──────────────────╮
     //    Helper Methods
     // ╰──────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -331,10 +331,41 @@ public final class Preconditions {
         }
     }
 
+    private static void performMinValidation(
+            String value,
+            int min,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        validateMinArgument(value, min);
+
+        if (value == null) {
+            if (min == 0) {
+                return; // null 허용: min이 0이면
+            }
+            throw new NullPointerException("String must not be null if min is not 0.");
+        }
+
+        if (value.isEmpty() && min == 0) {
+            return;
+        }
+
+        if (value.length() < min) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void validateLengthArgument(String value, int min, int max) {
         assert min >= 0 : "min cannot be less than 0";
         assert max >= 0 : "max cannot be less than 0";
         assert min <= max : "max must be greater than or equal to " + min;
+
+        if (value == null && min != 0) {
+            throw new NullPointerException("String must not be null if min is not 0.");
+        }
+    }
+
+    private static void validateMinArgument(String value, int min) {
+        assert min >= 0 : "min cannot be less than 0";
 
         if (value == null && min != 0) {
             throw new NullPointerException("String must not be null if min is not 0.");

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -5,6 +5,8 @@ import nettee.common.ErrorCode;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public final class Preconditions {
     private Preconditions() {}
@@ -742,6 +744,19 @@ public final class Preconditions {
         }
     }
 
+    private static void performRegexValidation(
+            String value,
+            String regexp,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        assert regexp != null : "Pattern must not be null.";
+        Pattern pattern = compileRegex(regexp);
+
+        if (!pattern.matcher(value).matches()) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void validateLengthArgument(String value, int min, int max) {
         assert min >= 0 : "min cannot be less than 0";
         assert max >= 0 : "max cannot be less than 0";
@@ -779,5 +794,13 @@ public final class Preconditions {
 
     private static void validateMaxArgument(int max) {
         assert max >= 0 : "max cannot be less than 0";
+    }
+
+    private static Pattern compileRegex(String regex) {
+        try {
+            return Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid regex: " + regex, e);
+        }
     }
 }


### PR DESCRIPTION
## Issues

- Resolves #138 
  - Resolves #139 
  - Resolves #140 
  - Resolves #141 
  - Resolves #142 
  - Resolves #143 
  - Resolves #144 
  - Resolves #145 
  - Resolves #146 
  - Resolves #147 
  - Resolves #148 

## Description

- 유효성을 커스텀하는 등 직접 핸들링해야 할 때를 위한 유틸리티 클래스를 추가합니다.
  - `spring-boot-starter-validation`, hibernate 유효성 등과 사용감에서 나타나는 차이는 대표적으로 다음과 같습니다.
    - `strip`이나 `substring`, `replaceAll` 등 문자열을 전처리한 후 길이, 정규식 등 유효성을 체크할 때, 이처럼 커스텀된 메서드와 조합하면 편리합니다.
    - 반환하는 예외를 `CustomException` 등 우리가 원하는 런타임 예외 종류로 지정할 수 있습니다.

<br />

## Review Points

- 한 번에 작업했다 보니 코드가 길어 리뷰가 까다롭습니다.
- 위 연결된 이슈 목록을 살피고, 부족한 유효성 항목이 있다면 새로운 이슈로 등록해 주시면 감사드리겠습니다.  
    : 예를 들어 시간 관련 유효성도 추가할 수 있지만, 사용처가 제한되므로 아직 작성하지 않는 것이 낫다고 보았습니다.

<br />

## How Has This Been Tested?

- 분량이 많지만, 오류를 발견한 후에도 수정할 수 있으므로 이번에는 테스트 생략했습니다.

<br />

## Additional Notes

**간단한 용례**

static import는 일반적으로 삼가는 관례를 따르지만, 이처럼 재사용성이 높은 일부 유틸리티 함수는 static import를 허용하곤 합니다.

```java
@Builder
public record BlogCreateCommand(
        String userId,
        String name,
        String url
) {
    public BlogCreateCommand {
        validateNotBlank(userId, BLOG_OWNER_ID_REQUIRED);
        validateNotBlank(name, BLOG_NAME_REQUIRED);
        validateNotBlank(url, BLOG_URL_REQUIRED);

        // 앞뒤 공백 문자를 제거 후 유효성 확인
        name = name.strip();
        url = url.strip();

        validateLength(name, 3, 30, BLOG_NAME_INVALID_LENGTH);
        validateRegex(url, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
        validateLength(url, 3, 15, BLOG_URL_INVALID_LENGTH);
    }
}
```