### PR TITLE
Blog > WebMVC: 블로그 수정, 삭제 API 엔드포인트 추가

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
@@ -41,9 +41,13 @@ public class BlogCommandService implements BlogCreateUseCase, BlogUpdateUseCase,
     }
 
     @Override
-    public Blog update(String blogId, String name, String url) {
-        Objects.requireNonNull(blogId, "blogId cannot be null");
-        if (name == null || name.isBlank()) {
+    public Blog update(Blog blog) {
+        Objects.requireNonNull(blog, "Blog cannot be null");
+        String blogId = Objects.requireNonNull(blog.getId(), "blogId cannot be null");
+        String name = Objects.requireNonNull(blog.getName(), "blog name cannot be null");
+        String url = Objects.requireNonNull(blog.getUrl(), "blog url identifier cannot be null");
+
+        if (name.isBlank()) {
             throw BLOG_NAME_CANNOT_BE_BLANK.exception();
         }
 

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
@@ -61,7 +61,7 @@ public class BlogCommandService implements BlogCreateUseCase, BlogUpdateUseCase,
                 .url(url)
                 .update();
 
-        return commandRepository.save(entity);
+        return commandRepository.update(entity);
     }
 
     @Override

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogUpdateUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogUpdateUseCase.java
@@ -3,6 +3,6 @@ package nettee.blolet.blog.application.usecase;
 import nettee.blolet.blog.domain.Blog;
 
 public interface BlogUpdateUseCase {
-    Blog update(String blogId, String name, String url);
+    Blog update(Blog blog);
     Blog updateUrl(String blogId, String url);
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
@@ -1,6 +1,5 @@
 package nettee.blolet.blog.web;
 
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
@@ -65,7 +65,7 @@ public class BlogCommandApi {
             description = "블로그를 구독합니다."
     )
     public BlogSubscribeResponse subscribeBlog(@PathVariable("blogId") String blogId) {
-        return null;
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @DeleteMapping("/{blogId}/subscribe")
@@ -74,7 +74,7 @@ public class BlogCommandApi {
             description = "구독한 블로그의 구독을 취소합니다. (TODO 정책 논의: 아마도 뉴스레터 구독도 함께 취소될 것입니다.)"
     )
     public BlogUnsubscribeResponse unsubscribeBlog(@PathVariable("blogId") String blogId) {
-        return null;
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @PostMapping("/{blogId}/newsletter")
@@ -83,7 +83,7 @@ public class BlogCommandApi {
             description = "블로그의 뉴스레터 수신을 동의합니다. (TODO 정책 논의: 아직 구독하지 않은 블로그라면 아마도 구독도 함께 될 것입니다.)"
     )
     public BlogNewsletterSubscribeResponse subscribeNewsletter(@PathVariable("blogId") String blogId) {
-        return null;
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @DeleteMapping("/{blogId}/newsletter")
@@ -92,6 +92,6 @@ public class BlogCommandApi {
             description = "블로그의 뉴스레터 수신 동의를 철회합니다."
     )
     public BlogNewsletterUnsubscribeResponse unsubscribeNewsletter(@PathVariable("blogId") String blogId) {
-        return null;
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
@@ -4,12 +4,14 @@ package nettee.blolet.blog.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.application.usecase.BlogUpdateUseCase;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogNewsletterSubscribeResponse;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogNewsletterUnsubscribeResponse;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogSubscribeResponse;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUnsubscribeResponse;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateCommand;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateResponse;
+import nettee.blolet.blog.web.mapper.BlogDtoMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,10 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Blog", description = "Blog API")
 public class BlogCommandApi {
 
-//    @GetMapping("/user/{username}/blogs")
-//    public List<Void> findAllByUserId(@PathVariable("username") String username) {
-//        throw new Error("아직 다중 블로그 제공이 기획되지 않음.");
-//    }
+    private final BlogUpdateUseCase updateUseCase;
+    private final BlogDtoMapper mapper;
 
     @PutMapping("/{blogId}")
     @Operation(
@@ -37,7 +37,8 @@ public class BlogCommandApi {
             description = "사용자가 소유한 블로그 정보를 수정합니다."
     )
     public BlogUpdateResponse updateBlog(@PathVariable("blogId") String blogId, @RequestBody BlogUpdateCommand dto) {
-        return null;
+        var domain = mapper.toDomain(blogId, dto);
+        return mapper.toResponse(updateUseCase.update(domain));
     }
 
     /**

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
@@ -4,6 +4,7 @@ package nettee.blolet.blog.web;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.application.usecase.BlogDeleteUseCase;
 import nettee.blolet.blog.application.usecase.BlogUpdateUseCase;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogNewsletterSubscribeResponse;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogNewsletterUnsubscribeResponse;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class BlogCommandApi {
 
     private final BlogUpdateUseCase updateUseCase;
+    private final BlogDeleteUseCase deleteUseCase;
     private final BlogDtoMapper mapper;
 
     @PutMapping("/{blogId}")
@@ -52,7 +54,10 @@ public class BlogCommandApi {
             summary = "블로그 삭제",
             description = "사용자가 소유한 블로그 중 하나를 삭제합니다."
     )
-    public void deleteBlog(@PathVariable("blogId") String blogId) {}
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteBlog(@PathVariable("blogId") String blogId) {
+        deleteUseCase.deleteById(blogId);
+    }
 
     @PostMapping("/{blogId}/subscribe")
     @Operation(

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
@@ -5,6 +5,16 @@ import lombok.Builder;
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
 import nettee.blolet.blog.readmodel.BlogReadModels.BlogDetail;
 
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_FORMAT;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_REQUIRED;
+import static nettee.common.validation.Preconditions.validateLength;
+import static nettee.common.validation.Preconditions.validateNotBlank;
+import static nettee.common.validation.Preconditions.validateRegex;
+
 public final class BlogCommandDto {
 
     @Builder
@@ -13,7 +23,20 @@ public final class BlogCommandDto {
             String name,
             @Schema(description = "블로그 주소 식별자", example = "wch-os")
             String url
-    ) {}
+    ) {
+        public BlogUpdateCommand {
+            validateNotBlank(name, BLOG_NAME_REQUIRED);
+            validateNotBlank(url, BLOG_URL_REQUIRED);
+
+            // 앞뒤 공백 문자를 제거 후 유효성 확인
+            name = name.strip();
+            url = url.strip();
+
+            validateLength(name, 3, 30, BLOG_NAME_INVALID_LENGTH);
+            validateRegex(url, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
+            validateLength(url, 3, 15, BLOG_URL_INVALID_LENGTH);
+        }
+    }
 
     @Builder
     public record BlogUpdateResponse(BlogDetail blog) {}

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
@@ -10,7 +10,9 @@ public final class BlogCommandDto {
     @Builder
     public record BlogUpdateCommand(
             @Schema(description = "블로그 이름", example = "Sun☀️ 好 Moon🌙")
-            String name
+            String name,
+            @Schema(description = "블로그 주소 식별자", example = "wch-os")
+            String url
     ) {}
 
     @Builder

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/mapper/BlogDtoMapper.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/mapper/BlogDtoMapper.java
@@ -4,9 +4,11 @@ import nettee.blolet.blog.domain.Blog;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateCommand;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateResponse;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface BlogDtoMapper {
+    @Mapping(target = "id", source = "blogId")
     Blog toDomain(String blogId, BlogUpdateCommand dto);
     BlogUpdateResponse toResponse(Blog blog);
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/mapper/BlogDtoMapper.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/mapper/BlogDtoMapper.java
@@ -1,0 +1,12 @@
+package nettee.blolet.blog.web.mapper;
+
+import nettee.blolet.blog.domain.Blog;
+import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateCommand;
+import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BlogDtoMapper {
+    Blog toDomain(String blogId, BlogUpdateCommand dto);
+    BlogUpdateResponse toResponse(Blog blog);
+}


### PR DESCRIPTION
## Issues

- Resolves #155 
- Resolves #156 
- Resolves #150

<br />

## Description

- 블로그 수정 및 삭제 API를 동작 가능한 상태로 구현합니다.
- Rel: #9 > #150 

<br />

## Review Points

- 간단한 작업이지만 놓친 부분이 있다면 말씀해 주세요.

<br />

## How Has This Been Tested?

- 포스트맨으로 실행하여 확인하였습니다.  
  
  **Update**
  
  <table>
  <tr>
    <td>
      <img width="816" height="550" alt="포스트맨 블로그 수정 실행 스크린샷. 수정된 내용이 담긴 바디가 응답됨." src="https://github.com/user-attachments/assets/1024803d-f56b-4e61-9f9c-1c89bef45910" />  
    </td>
  </tr>
  </table>
  
  **Delete**  
  
  <table>
  <tr>
    <td>
  <img width="816" height="550" alt="포스트맨 블로그 삭제 실행 스크린샷. 204 No Content 상태로 빈 바디가 응답됨." src="https://github.com/user-attachments/assets/c72673d6-e6c9-4b04-82df-d5f29666c1a5" />
    </td>
  </tr>
  </table>

<br />

## Additional Notes

_No response_