### PR TITLE
Blog: 블로그 소유권 확인

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogQueryRepositoryPort.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogQueryRepositoryPort.java
@@ -1,0 +1,12 @@
+package nettee.blolet.blog.application.port;
+
+import nettee.blolet.blog.domain.Blog;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public interface BlogQueryRepositoryPort {
+    Optional<Blog> findById(String id);
+    Map<String, Blog> findAllByProfileIdIn(Set<String> userIds);
+}

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogQueryService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogQueryService.java
@@ -1,0 +1,46 @@
+package nettee.blolet.blog.application.service;
+
+import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.application.port.BlogQueryRepositoryPort;
+import nettee.blolet.blog.application.usecase.BlogReadUseCase;
+import nettee.blolet.blog.application.usecase.BlogOwnershipVerifyUseCase;
+import nettee.blolet.blog.domain.Blog;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class BlogQueryService implements BlogReadUseCase, BlogOwnershipVerifyUseCase {
+
+    private final BlogQueryRepositoryPort repository;
+
+    @Override
+    public Blog findById(String id) {
+        return repository.findById(id).orElseThrow(BLOG_NOT_FOUND::exception);
+    }
+
+    @Override
+    public Map<String, Blog> findByUserProfileIds(Set<String> profileIds) {
+        return repository.findAllByProfileIdIn(profileIds);
+    }
+
+    @Override
+    public boolean verifyOwnershipByUserId(String userId, String blogId) {
+        var blog = repository.findById(blogId)
+                .orElseThrow(BLOG_NOT_FOUND::exception);
+        return Objects.equals(userId, blog.getUserId());
+    }
+
+    @Override
+    public boolean verifyOwnershipByProfileId(String profileId, String blogId) {
+        throw new UnsupportedOperationException("Not supported yet.");
+//        var blog = repository.findById(blogId)
+//                .orElseThrow(BLOG_NOT_FOUND::exception);
+//        return Objects.equals(profileId,blog.getProfileId());
+    }
+}

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogOwnershipVerifyUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogOwnershipVerifyUseCase.java
@@ -1,0 +1,6 @@
+package nettee.blolet.blog.application.usecase;
+
+public interface BlogOwnershipVerifyUseCase {
+    boolean verifyOwnershipByUserId(String userId, String blogId);
+    boolean verifyOwnershipByProfileId(String profileId, String blogId);
+}

--- a/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/RdbBlogQueryRepositoryAdapter.java
+++ b/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/RdbBlogQueryRepositoryAdapter.java
@@ -1,0 +1,32 @@
+package nettee.blolet.blog.rdb;
+
+import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.application.port.BlogQueryRepositoryPort;
+import nettee.blolet.blog.domain.Blog;
+import nettee.blolet.blog.rdb.mapper.BlogEntityMapper;
+import nettee.blolet.blog.rdb.repository.BlogQueryJpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class RdbBlogQueryRepositoryAdapter implements BlogQueryRepositoryPort {
+
+    private final BlogQueryJpaRepository queryJpaRepository;
+    private final BlogEntityMapper mapper;
+
+    @Override
+    public Optional<Blog> findById(String id) {
+        Long longId = Long.valueOf(id);
+        return queryJpaRepository.findById(longId)
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public Map<String, Blog> findAllByProfileIdIn(Set<String> userIds) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/repository/BlogQueryJpaRepository.java
+++ b/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/repository/BlogQueryJpaRepository.java
@@ -1,0 +1,7 @@
+package nettee.blolet.blog.rdb.repository;
+
+import nettee.blolet.blog.rdb.entity.BlogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogQueryJpaRepository extends JpaRepository<BlogEntity, Long> {
+}

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
@@ -42,12 +42,6 @@ public class BlogCommandApi {
         return mapper.toResponse(updateUseCase.update(domain));
     }
 
-    /**
-     * TODO 예상되는 정책 또는 논의 (블로그 상세 조회)
-     * <ul>
-     *     <li>Q. 사용자는 최소 하나의 블로그를 갖고 있어야 할까요?</li>
-     * </ul>
-     */
     @DeleteMapping("/{blogId}")
     @Operation(
             summary = "블로그 삭제",

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
@@ -70,16 +70,21 @@ public class BlogQueryApi {
             @RequestParam(value = "profileId", required = false) String profileId,
             @RequestParam(value = "userId", required = false) String userId
     ) {
-        String ownerId = profileId != null ? profileId : userId;
+        boolean usesProfileId = profileId != null;
+        String ownerId = usesProfileId ? profileId : userId;
 
-        // profileId 또는 userId가 필요함.
+        // Exception: profileId 또는 userId가 필요함.
         if (ownerId == null) {
             var cause = new NullPointerException("사용자의 `profileId` 또는 `userId`가 필요합니다.");
             throw BLOG_OWNER_ID_REQUIRED.exception(cause);
         }
 
+        boolean isOwner = usesProfileId ?
+                verifyOwnershipUseCase.verifyOwnershipByProfileId(userId, blogId) :
+                verifyOwnershipUseCase.verifyOwnershipByUserId(userId, blogId);
+
         return BlogOwnershipVerifyResponse.builder()
-                .isOwner(verifyOwnershipUseCase.verifyOwnershipByUserId(userId, blogId))
+                .isOwner(isOwner)
                 .build();
     }
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
@@ -39,6 +39,12 @@ public class BlogQueryApi {
         return null;
     }
 
+    /**
+     * TODO 예상되는 정책 또는 논의 (블로그 상세 조회)
+     * <ul>
+     *     <li>Q. 사용자는 최소 하나의 블로그를 갖고 있어야 할까요?</li>
+     * </ul>
+     */
     @GetMapping("/{blogId}")
     @Operation(
             summary = "블로그 상세 조회",

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogQueryApi.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.application.usecase.BlogOwnershipVerifyUseCase;
 import nettee.blolet.blog.web.dto.BlogQueryDto.BlogDetailViewResponse;
 import nettee.blolet.blog.web.dto.BlogQueryDto.BlogListViewResponse;
+import nettee.blolet.blog.web.dto.BlogQueryDto.BlogOwnershipVerifyResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,11 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("blogs")
 @Tag(name = "Blog")
 public class BlogQueryApi {
+
+    private final BlogOwnershipVerifyUseCase verifyOwnershipUseCase;
 
     /**
      * TODO 예상되는 정책 또는 논의 (블로그 목록 조회)
@@ -52,5 +58,28 @@ public class BlogQueryApi {
     )
     public BlogDetailViewResponse findByBlogId(@PathVariable("blogId") String blogId) {
         return null;
+    }
+
+    @GetMapping("/{blogId}/ownership")
+    @Operation(
+            summary = "사용자의 블로그 소유권 확인",
+            description = "파라미터로 전달한 사용자의 블로그 소유권을 확인합니다."
+    )
+    public BlogOwnershipVerifyResponse validateBlogOwnership(
+            @PathVariable("blogId") String blogId,
+            @RequestParam(value = "profileId", required = false) String profileId,
+            @RequestParam(value = "userId", required = false) String userId
+    ) {
+        String ownerId = profileId != null ? profileId : userId;
+
+        // profileId 또는 userId가 필요함.
+        if (ownerId == null) {
+            var cause = new NullPointerException("사용자의 `profileId` 또는 `userId`가 필요합니다.");
+            throw BLOG_OWNER_ID_REQUIRED.exception(cause);
+        }
+
+        return BlogOwnershipVerifyResponse.builder()
+                .isOwner(verifyOwnershipUseCase.verifyOwnershipByUserId(userId, blogId))
+                .build();
     }
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogQueryDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogQueryDto.java
@@ -17,4 +17,9 @@ public final class BlogQueryDto {
     public record BlogDetailViewResponse(
             BlogDetail blog
     ) {}
+
+    @Builder
+    public record BlogOwnershipVerifyResponse(
+            Boolean isOwner
+    ) {}
 }


### PR DESCRIPTION
<!--
<br />
<br />

<table border="3" align="center">
<tr height="45">
  <td> 🏗️ </td>
  <td>이 PR은 아직 draft입니다. 이전 작업분을 병합한 후 리뷰를 오픈하겠습니다.</td>
</tr>
</table>

<br />

-->
## Issues

- Resolves #164 
- Resolves #165 
- Resolves #166 
- Resolves #167 

<br />

## Description

- 블로그 소유권을 확인하는 API를 추가합니다.

<br />

## Review Points

<!-- 리뷰어가 중점적으로 확인할 항목을 작성해 주세요. -->
<!-- (Ex: 구현 로직, API 스펙, 테스트 케이스 등) -->

- **구현 로직**: 블로그 소유권 확인 API 진입점부터 서비스, RDB 어댑터까지.
- **API 스펙**: 사용하기 편리해 보이는지  
  주로 S2S 요청일 것 같지만, 보안상 민감하게 다룰 필요가 없어 선택한 스펙  
  : GET 메서드, path variable 및 request param으로 인자를 전달받는 등. (`userId`, `profileId` 등이 네트워크상에 노출됨.)

<br />

## How Has This Been Tested?

- 포스트맨으로 실행하여 육안으로 확인했습니다.  
  <img width="881" height="454" alt="블로그 소유권 확인 에이피아이의 포스트맨 캡처" src="https://github.com/user-attachments/assets/452fa51c-3cc4-40ba-8175-2e4d22b5ade8" />

<br />

## Additional Notes

_No response_
