### PR TITLE
Flyway: Article Likes 테이블 createAt/updateAt 필드명 오타 수정

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_14__create_tb_article_likes.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_14__create_tb_article_likes.sql
@@ -1,16 +1,16 @@
 CREATE SCHEMA IF NOT EXISTS "article";
 
 CREATE TABLE IF NOT EXISTS "article"."article_likes" (
-    "id"          BIGINT,
-    "user_id"     BIGINT,
-    "profile_id"  BIGINT,
-    "article_id"  BIGINT,
+    "id"           BIGINT,
+    "user_id"      BIGINT,
+    "profile_id"   BIGINT,
+    "article_id"   BIGINT,
 
-    "count"       VARCHAR(255),
+    "count"        VARCHAR(255),
 
-    "status"      VARCHAR(255),
-    "create_at"   TIMESTAMP     DEFAULT NOW()   NOT NULL,
-    "update_at"   TIMESTAMP     DEFAULT NOW()   NOT NULL,
+    "status"       VARCHAR(255),
+    "created_at"   TIMESTAMP      DEFAULT NOW()   NOT NULL,
+    "updated_at"   TIMESTAMP      DEFAULT NOW()   NOT NULL,
 
     CONSTRAINT "pk_article_likes" PRIMARY KEY ("id")
 );
@@ -22,5 +22,5 @@ COMMENT ON COLUMN "article"."article_likes"."article_id" IS '아티클테이블 
 
 COMMENT ON COLUMN "article"."article_likes"."count"      IS '한 사용자가 누른 좋아요 수';
 
-COMMENT ON COLUMN "article"."article_likes"."create_at"  IS '좋아요 생성일자';
-COMMENT ON COLUMN "article"."article_likes"."update_at"  IS '좋아요 수정일자';
+COMMENT ON COLUMN "article"."article_likes"."created_at"  IS '좋아요 생성일자';
+COMMENT ON COLUMN "article"."article_likes"."updated_at"  IS '좋아요 수정일자';


### PR DESCRIPTION
## Issues
- Resolves #179 

## Description

- article_likes 테이블의 컬럼명에 있던 오타를 수정합니다.
  - 기존 createAt, updateAt으로 되어 있던 컬럼명을 createdAt, updatedAt으로 변경하였습니다.

<br />

## Review Points

- Flyway 스크립트가 올바르게 작성되었는지 확인 부탁드립니다.

<br />

## How Has This Been Tested?

- 로컬 개발 환경에서 Flyway 마이그레이션을 실행하여 DB 툴을 이용하여 컬럼명이 정상적으로 변경된걸 확인하였습니다.

<br />
