### PR TITLE
Monolith > Flyway: 블로그 테이블을 기획에 맞게 수정합니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
@@ -3,14 +3,14 @@ CREATE SCHEMA IF NOT EXISTS "auth";
 CREATE TABLE IF NOT EXISTS "auth"."user" (
     "id"	            BIGINT          ,
     -- 인증
-    "username"	        VARCHAR(255)   ,
-    "password"	        VARCHAR(255)   ,
+    "username"	        VARCHAR(255)    ,
+    "password"	        VARCHAR(255)    ,
     -- 보호
     "login_retry_count"	INT	            DEFAULT 0,
     "locked_until"	    TIMESTAMP       ,
     -- 프로필 비정규화
-    "nickname"	        VARCHAR(255)   ,
-    "email"	            VARCHAR(255)   ,
+    "nickname"	        VARCHAR(255)    ,
+    "email"	            VARCHAR(255)    ,
     -- 공통 컬럼
     "status"	        VARCHAR	        DEFAULT 'ACTIVE'    ,
     "created_at"	    TIMESTAMP		DEFAULT NOW()       NOT NULL,
@@ -20,11 +20,12 @@ CREATE TABLE IF NOT EXISTS "auth"."user" (
 COMMENT ON COLUMN "auth"."user"."id"                  IS '사용자 테이블 PK';
 COMMENT ON COLUMN "auth"."user"."username"            IS '사용자의실명';
 COMMENT ON COLUMN "auth"."user"."password"            IS '로그인 비밀번호';
-COMMENT ON COLUMN "auth"."user"."login_retry_count"   IS '로그인 실패 횟수 (추가)';
-COMMENT ON COLUMN "auth"."user"."locked_until"        IS '계정 잠금 해제 예정 시각, 잠금 시 사용 (추가)';
+COMMENT ON COLUMN "auth"."user"."login_retry_count"   IS '로그인 실패 횟수';
+COMMENT ON COLUMN "auth"."user"."locked_until"        IS '계정 잠금 해제 예정 시각, 잠금 시 사용';
 COMMENT ON COLUMN "auth"."user"."nickname"            IS '사용자닉네임';
 COMMENT ON COLUMN "auth"."user"."email"               IS '사용자의 이메일 주소';
-COMMENT ON COLUMN "auth"."user"."status"              IS '사용자 계정 상태: ACTIVE(활동), DORMANT(휴먼), WITHDRAWAL(탈퇴)';
+COMMENT ON COLUMN "auth"."user"."status"              IS
+        '사용자 계정 상태: PENDING(가입 대기), ACTIVE(활동), SUSPENDED(정지), PROTECTED(보호), REMOVED(탈퇴)';
 COMMENT ON COLUMN "auth"."user"."created_at"          IS '생성일자';
 COMMENT ON COLUMN "auth"."user"."updated_at"          IS '수정일자';
 

--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_9__create_tb_blog.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_9__create_tb_blog.sql
@@ -1,23 +1,26 @@
 CREATE SCHEMA IF NOT EXISTS "blog";
 
 CREATE TABLE IF NOT EXISTS "blog"."blog" (
-    "id"         BIGINT,
-    "user_id"    BIGINT,
-    "profile_id" BIGINT,
-    "username"   VARCHAR(255),
-    "nickname"   VARCHAR(255),
-    "name"       VARCHAR(255),
-    "url"        VARCHAR(255),
-    "created_at" TIMESTAMP   DEFAULT NOW()  NOT NULL,
-    "updated_at" TIMESTAMP   DEFAULT NOW()  NOT NULL
+    "id"            BIGINT,
+    "user_id"       BIGINT,
+    "profile_id"    BIGINT,
+    "username"      VARCHAR(255),
+    "nickname"      VARCHAR(255),
+    "name"          VARCHAR(255),
+    "url_identifier" VARCHAR(255),
+    "created_at"    TIMESTAMP   DEFAULT NOW()  NOT NULL,
+    "updated_at"    TIMESTAMP   DEFAULT NOW()  NOT NULL,
+
+    CONSTRAINT "pk_blog" PRIMARY KEY ("id"),
+    CONSTRAINT "uq_blog_url_identifier" UNIQUE ("url_identifier")
 );
 
-COMMENT ON COLUMN "blog"."blog"."id"         IS '블로그테이블의 PK';
-COMMENT ON COLUMN "blog"."blog"."user_id"    IS '사용자테이블 PK';
-COMMENT ON COLUMN "blog"."blog"."name"       IS '사용자 블로그명';
-COMMENT ON COLUMN "blog"."blog"."url"        IS '사용자 블로그 URL 주소';
-COMMENT ON COLUMN "blog"."blog"."created_at" IS '생성일자';
-COMMENT ON COLUMN "blog"."blog"."updated_at" IS '수정일자';
-
-ALTER TABLE "blog"."blog" ADD CONSTRAINT "pk_blog" PRIMARY KEY ("id");
-ALTER TABLE "blog"."blog" ADD CONSTRAINT "uq_blog_url" UNIQUE ("url");
+COMMENT ON COLUMN "blog"."blog"."id"            IS '블로그 테이블 PK';
+COMMENT ON COLUMN "blog"."blog"."user_id"       IS '사용자 테이블 PK';
+COMMENT ON COLUMN "blog"."blog"."profile_id"    IS '프로필 테이블 PK';
+COMMENT ON COLUMN "blog"."blog"."username"      IS '계정 고유 아이디';
+COMMENT ON COLUMN "blog"."blog"."nickname"      IS '프로필 이름';
+COMMENT ON COLUMN "blog"."blog"."name"          IS '사용자 블로그명';
+COMMENT ON COLUMN "blog"."blog"."url_identifier" IS '사용자 블로그 URL 주소';
+COMMENT ON COLUMN "blog"."blog"."created_at"    IS '생성일자';
+COMMENT ON COLUMN "blog"."blog"."updated_at"    IS '수정일자';


### PR DESCRIPTION
## Issues

- Resolves #184 

## Description

- Blog 테이블은 flyway상으로 대부분 기획을 반영하고 있었습니다.
- Rename: `url` to `url_identifier` 컬럼
- Rel: #183 

<br />

## Review Points

- 인텔리제이 기준으로 탭 사이즈(4)가 정상적으로 나옵니다.

<br />

## How Has This Been Tested?

- 수정된 테이블이 생성되는 것을 확인했습니다.  
    **컨테이너 내리기**  
    ```console
    # 필요 시 권한 부여 (예시)
    # chmod 755 설명:
    #  소유자: 읽기/쓰기/실행 (0b0111 == 7)
    #  그룹 사용자: 읽기/실행 (0b0101 == 5)
    #  기타 사용자: 읽기/실행 (0b0101 == 5)
    chmod 755 ./compose-monolith
    
    # 컴포넌트 내리기
    ./compose-monolith down -v
    ```  
    **컨테이너 재게시**
    ```console
    ./compose-monolith up -d
    ```

<br />

## Additional Notes

_No response_
