### PR TITLE
Monolith: JSON Response에서 Null 필드는 직렬화하지 않습니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/application.yml
+++ b/monolith/main-runner/src/main/resources/application.yml
@@ -2,6 +2,15 @@ spring:
   application:
     name: main
 
+  config:
+    import:
+      - properties/web/main.cors.yml
+      - properties/persistence/main.snowflake.yml
+      - properties/client/main.client.yml
+      - properties/jwt/main.jwt.yml
+      - properties/mail/main.mail.yml
+      - optional:file:.env[.properties]
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${BOARD_POSTGRESQL_URL}
@@ -13,19 +22,13 @@ spring:
       host: ${REDIS_URL}
       port: ${REDIS_PORT}
 
-  config:
-    import:
-      - properties/web/main.cors.yml
-      - properties/persistence/main.snowflake.yml
-      - properties/client/main.client.yml
-      - properties/jwt/main.jwt.yml
-      - properties/mail/main.mail.yml
-      - optional:file:.env[.properties]
-
   flyway:
     baseline-on-migrate: true
     locations:
       - db/migration/v1
+
+  jackson:
+    default-property-inclusion: non_null
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Issues

- Resolves #214 

## Description

- JSON 직렬화 시, 기본적으로 `null`이 아닌 필드만 포함하도록 설정합니다.

<br />

## Review Points

_No response_

<br />

## How Has This Been Tested?

- 테스트를 생략했습니다.

<br />

## Additional Notes

주요 커밋:

````markdown
feat(monolith): set `spring.jackson.default-property-inclusion` to `non_null` to omit `null` fields in json responses

Applies globally to JSON serialization and can reduce payload size. Verify any clients that rely on explicit `null` values.

```yaml
spring:
  jackson:
    default-property-inclusion: non_null
```
````