### PR TITLE
Draft > RDB: Base 엔티티를 상속받는 모든 엔티티가 상위 클래스에 필드를 전달합니다.

### DIFF
--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
@@ -29,7 +29,7 @@ public class DraftBlockEntity extends SnowflakeBaseTimeEntity {
     public DraftBlockEntityStatus status;
 
     @Builder(
-            builderClassName = "updateDraftBlockEntityBuilder",
+            builderClassName = "UpdateDraftBlockEntityBuilder",
             builderMethodName = "prepareDraftBlockEntityUpdate",
             buildMethodName = "update"
     )
@@ -47,7 +47,7 @@ public class DraftBlockEntity extends SnowflakeBaseTimeEntity {
     }
 
     @Builder(
-            builderClassName = "updateStatusDraftBlockEntityBuilder",
+            builderClassName = "UpdateStatusDraftBlockEntityBuilder",
             builderMethodName = "prepareDraftBlockEntityStatusUpdate",
             buildMethodName = "updateStatus"
     )

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
@@ -2,9 +2,6 @@ package nettee.draft.draftblock.driven.rdb.entity;
 
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,15 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatus;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatusConverter;
-import nettee.jpa.support.LongBaseTimeEntity;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.GenericGenerator;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.Instant;
 import java.util.Objects;
 
 @Getter

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
@@ -10,12 +10,10 @@ import lombok.NoArgsConstructor;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatus;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatusConverter;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
-import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.Objects;
 
 @Getter
-@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(schema = "article", name = "draft_block")

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatus;
 import nettee.draft.draftblock.driven.rdb.entity.type.DraftBlockEntityStatusConverter;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
@@ -14,6 +15,7 @@ import nettee.jpa.support.SnowflakeBaseTimeEntity;
 import java.util.Objects;
 
 @Getter
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(schema = "article", name = "draft_block")

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/draftblock/driven/rdb/entity/DraftBlockEntity.java
@@ -28,17 +28,6 @@ public class DraftBlockEntity extends SnowflakeBaseTimeEntity {
     @Convert(converter = DraftBlockEntityStatusConverter.class)
     public DraftBlockEntityStatus status;
 
-    @Builder
-    public DraftBlockEntity(String content, Long blogId, Long draftId, Long articleId, Long nextBlockId, String type, DraftBlockEntityStatus status) {
-        this.content = content;
-        this.blogId = blogId;
-        this.draftId = draftId;
-        this.articleId = articleId;
-        this.nextBlockId = nextBlockId;
-        this.status = status;
-        this.type = type;
-    }
-
     @Builder(
             builderClassName = "updateDraftBlockEntityBuilder",
             builderMethodName = "prepareDraftBlockEntityUpdate",

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
@@ -10,12 +10,10 @@ import lombok.NoArgsConstructor;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatus;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatusConverter;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
-import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.Objects;
 
 @Getter
-@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(schema = "article", name = "draft")

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
@@ -28,17 +28,6 @@ public class DraftEntity extends SnowflakeBaseTimeEntity {
     @Convert(converter = DraftEntityStatusConverter.class)
     public DraftEntityStatus status;
 
-    @Builder
-    public DraftEntity(String title, String content, Long blogId, Long articleId, Long entryBlockId, String path, DraftEntityStatus status) {
-        this.title = title;
-        this.content = content;
-        this.status = status;
-        this.blogId = blogId;
-        this.articleId = articleId;
-        this.entryBlockId = entryBlockId;
-        this.path = path;
-    }
-
     @Builder(
             builderClassName = "updateDraftEntityBuilder",
             builderMethodName = "prepareDraftEntityUpdate",

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatus;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatusConverter;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
@@ -14,6 +15,7 @@ import nettee.jpa.support.SnowflakeBaseTimeEntity;
 import java.util.Objects;
 
 @Getter
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(schema = "article", name = "draft")

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
@@ -29,7 +29,7 @@ public class DraftEntity extends SnowflakeBaseTimeEntity {
     public DraftEntityStatus status;
 
     @Builder(
-            builderClassName = "updateDraftEntityBuilder",
+            builderClassName = "UpdateDraftEntityBuilder",
             builderMethodName = "prepareDraftEntityUpdate",
             buildMethodName = "update"
     )
@@ -48,7 +48,7 @@ public class DraftEntity extends SnowflakeBaseTimeEntity {
     }
 
     @Builder(
-            builderClassName = "updateStatusDraftEntityBuilder",
+            builderClassName = "UpdateStatusDraftEntityBuilder",
             builderMethodName = "prepareDraftEntityStatusUpdate",
             buildMethodName = "updateStatus"
     )

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftEntity.java
@@ -2,9 +2,6 @@ package nettee.draft.driven.rdb.entity;
 
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,15 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatus;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatusConverter;
-import nettee.jpa.support.LongBaseTimeEntity;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.GenericGenerator;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.Instant;
 import java.util.Objects;
 
 @Getter


### PR DESCRIPTION
## Issues

- Resolves #219 

## Description

- 만약 다음 이슈를 처리한 작업이 병합되면, draft 모듈에서 맞추어야 할 부분을 작업했습니다. 그때 이 PR도 병합하면 됩니다.  
   #216
- Rel: #158 

<br />

## Review Points

_No response_

<br />

## How Has This Been Tested?

- 로컬에서 JPA core를 임시로 수정하여 확인했습니다. (JPA core는 커밋하지 않음.)

<br />

## Additional Notes

- 읽을거리: [MapStruct-JPA: Entity 상위클래스에 필드 주입](https://nettee.notion.site/mapstruct-jpa-entity)  
  https://nettee.notion.site/mapstruct-jpa-entity