### PR TITLE
Core > JPA: 모든 Base Entity 클래스가 수퍼빌더 등으로 필드를 전달받도록 수정합니다.

### DIFF
--- a/core/jpa-core/src/main/java/nettee/jpa/support/BaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/BaseTimeEntity.java
@@ -3,6 +3,8 @@ package nettee.jpa.support;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +12,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.io.Serializable;
 import java.time.Instant;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)

--- a/core/jpa-core/src/main/java/nettee/jpa/support/LongBaseEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/LongBaseEntity.java
@@ -5,9 +5,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.io.Serializable;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 public abstract class LongBaseEntity implements Serializable {

--- a/core/jpa-core/src/main/java/nettee/jpa/support/LongBaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/LongBaseTimeEntity.java
@@ -3,12 +3,16 @@ package nettee.jpa.support;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)

--- a/core/jpa-core/src/main/java/nettee/jpa/support/SnowflakeBaseEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/SnowflakeBaseEntity.java
@@ -3,10 +3,14 @@ package nettee.jpa.support;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import nettee.hibenate.annotation.SnowflakeGenerated;
 
 import java.io.Serializable;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 public abstract class SnowflakeBaseEntity implements Serializable {

--- a/core/jpa-core/src/main/java/nettee/jpa/support/SnowflakeBaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/SnowflakeBaseTimeEntity.java
@@ -3,12 +3,16 @@ package nettee.jpa.support;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)

--- a/core/jpa-core/src/main/java/nettee/jpa/support/UuidBaseEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/UuidBaseEntity.java
@@ -5,10 +5,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.io.Serializable;
 import java.util.UUID;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 public abstract class UuidBaseEntity implements Serializable {

--- a/core/jpa-core/src/main/java/nettee/jpa/support/UuidBaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/nettee/jpa/support/UuidBaseTimeEntity.java
@@ -3,12 +3,16 @@ package nettee.jpa.support;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
+@SuperBuilder
+@NoArgsConstructor
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)


### PR DESCRIPTION
## Issues

- Resolves #218 

## Description

- Rel: #158 
- Prerequisites: 
  - #216 
  - #224
 
```java
@SuperBuilder // 추가
@AllArgsConstructor // 추가
@NoArgsConstructor // 추가
@Entity
@Table(schema = "article", name = "article")
public class ArticleEntity extends SnowflakeBaseTimeEntity {
```
- Base 엔티티를 상속받는 ArticleEntity에 @SuperBuilder, @AllArgsConstructor, @NoArgsConstructor 어노테이션 추가하였습니다.
 
<br />

## Review Points

- 변경된 부분 가볍게 봐주시면 될듯합니다.

<br />

## How Has This Been Tested?

- 테스트 생략