### PR TITLE
Article > RDB: Base 엔티티를 상속받는 모든 엔티티가 상위 클래스에 필드를 전달합니다.

### DIFF
--- a/services/article/driven/rdb/src/main/java/nettee/article/driven/rdb/entity/ArticleEntity.java
+++ b/services/article/driven/rdb/src/main/java/nettee/article/driven/rdb/entity/ArticleEntity.java
@@ -3,13 +3,19 @@ package nettee.article.driven.rdb.entity;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import nettee.article.driven.rdb.entity.type.builder.ArticleEntityStatus;
 import nettee.article.driven.rdb.entity.type.builder.ArticleEntityStatusConverter;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
 
 import java.util.Objects;
 
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(schema = "article", name = "article")
 public class ArticleEntity extends SnowflakeBaseTimeEntity {


### PR DESCRIPTION
## Issues

- Resolves #218 

## Description

- Rel: #158 
- Prerequisites: 
  - #216 
  - #224
 
```java
@SuperBuilder // 추가
@AllArgsConstructor // 추가
@NoArgsConstructor // 추가
@Entity
@Table(schema = "article", name = "article")
public class ArticleEntity extends SnowflakeBaseTimeEntity {
```
- Base 엔티티를 상속받는 ArticleEntity에 @SuperBuilder, @AllArgsConstructor, @NoArgsConstructor 어노테이션 추가하였습니다.
 
<br />

## Review Points

- 변경된 부분 가볍게 봐주시면 될듯합니다.

<br />

## How Has This Been Tested?

- 테스트 생략