### PR TITLE
Auth > RDB: Base 엔티티를 상속받는 모든 엔티티가 상위 클래스에 필드를 전달합니다.

### DIFF
--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/entity/UserEntity.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/entity/UserEntity.java
@@ -5,14 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import nettee.jpa.support.SnowflakeBaseTimeEntity;
 
 @Entity
 @Table(schema = "auth", name = "user")
-@Builder
+@SuperBuilder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
## Issues

- Resolves #158
  - Resolves #221 

## Description

- #158 
- Domain → Entity 매핑과정에서 entity의 부모 필드가 매핑되지 않는 이슈를 해결합니다.

<br />

## Review Points

- 기존 @Builder에서 @SuperBuilder로 수정하였습니다.

<br />

## How Has This Been Tested?

- 테스트는 생략하였습니다.