### PR TITLE
Core > Security: 블로렛 JWT 인가 필터 구현

### DIFF
--- a/core/core.settings.gradle.kts
+++ b/core/core.settings.gradle.kts
@@ -10,6 +10,7 @@ include(
     ":exception-handler-core",
     ":cors-api",
     ":cors-webmvc",
+    ":security-blolet-jwt-filter",
     ":security-jwt-api",
     ":security-jwt-issuer",
     ":security-jwt-parser",
@@ -28,6 +29,7 @@ project(":jpa-core").projectDir = core["jpa-core"]!!
 project(":exception-handler-core").projectDir = core["exception-handler-core"]!!
 project(":cors-webmvc").projectDir = core["nettee-cors-webmvc"]!!
 project(":cors-api").projectDir = core["nettee-cors-api"]!!
+project(":security-blolet-jwt-filter").projectDir = core["blolet-jwt-filter"]!!
 project(":security-jwt-api").projectDir = core["jwt-api"]!!
 project(":security-jwt-issuer").projectDir = core["jwt-issuer"]!!
 project(":security-jwt-parser").projectDir = core["jwt-parser"]!!

--- a/core/security/jwt/blolet-jwt-filter/README.md
+++ b/core/security/jwt/blolet-jwt-filter/README.md
@@ -25,7 +25,7 @@ JWT 토큰을 사용한 인가 처리를 위한 필터 모듈입니다. </br>
 public class ExampleController {
     
     @GetMapping("/user-info")
-    public ResponseEntity<String> getUserInfo(@AuthUser AuthenticatedUser user) {
+    public ResponseEntity<String> getUserInfo(@AuthUser AuthorizedUser user) {
         // user 객체에 JWT 정보가 자동으로 주입됨
         String userId = user.getUserId();
         List<String> profileIds = user.getProfileIds();
@@ -50,7 +50,7 @@ JWT 토큰 검증 실패 시 다음과 같은 응답을 반환합니다.
 ```json
 {
   "error": "JWT 토큰이 만료되었습니다.",
-  "message": "Token has expired",
+  "message": "JWT has expired",
   "timestamp": "2025-01-01T00:00:00Z"
 }
 ```

--- a/core/security/jwt/blolet-jwt-filter/README.md
+++ b/core/security/jwt/blolet-jwt-filter/README.md
@@ -1,0 +1,58 @@
+# JWT 인가 필터 (blolet-jwt-filter)
+
+JWT 토큰을 사용한 인가 처리를 위한 필터 모듈입니다. </br> 
+초기 복잡성을 줄이기 위해 스프링 시큐리티 없이 구현합니다.
+
+## 1. 주요 기능
+
+- **인가 정책**: 인가가 필요하지 않은 경로에서의 요청은 통과
+- **JWT 토큰 검증**: HTTP 요청의 Authorization 헤더에서 JWT 토큰을 추출하고 검증
+- **@AuthUser 어노테이션**: 컨트롤러에서 JWT 사용자 정보를 자동으로 주입받을 수 있는 커스텀 어노테이션
+
+## 2. 의존성
+- `jwt-parser`: JWT 토큰 파싱 및 검증
+- `spring-boot-starter-web`: 스프링 웹 필터를 사용하기 위함
+
+
+
+## 3. 사용 예시
+### - @AuthUser 어노테이션 사용
+
+컨트롤러에서 `@AuthUser` 어노테이션을 사용하여 JWT 사용자 정보를 자동으로 주입받을 수 있습니다.
+
+```java
+@RestController
+public class ExampleController {
+    
+    @GetMapping("/user-info")
+    public ResponseEntity<String> getUserInfo(@AuthUser AuthenticatedUser user) {
+        // user 객체에 JWT 정보가 자동으로 주입됨
+        String userId = user.getUserId();
+        List<String> profileIds = user.getProfileIds();
+        
+        if (user.hasRole("ADMIN")) {
+            return ResponseEntity.ok("Admin access granted");
+        }
+        
+        if (user.hasProfileId("wch-os")) {
+            return ResponseEntity.ok("Profile access granted");
+        }
+        
+        return ResponseEntity.ok("User info: " + userId);
+    }
+}
+```
+
+## 4. 에러 처리
+
+JWT 토큰 검증 실패 시 다음과 같은 응답을 반환합니다.
+
+```json
+{
+  "error": "JWT 토큰이 만료되었습니다.",
+  "message": "Token has expired",
+  "timestamp": "2025-01-01T00:00:00Z"
+}
+```
+
+

--- a/core/security/jwt/blolet-jwt-filter/build.gradle.kts
+++ b/core/security/jwt/blolet-jwt-filter/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    implementation(project(":security-jwt-parser"))
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+}

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthUser.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthUser.java
@@ -1,0 +1,16 @@
+package nettee.jwt.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * JWT 토큰 내의 사용자 정보를 주입받기 위한 어노테이션
+ * 컨트롤러 메서드의 파라미터에 사용하여 현재 인증된 사용자 정보를 자동으로 주입받을 수 있다.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+}
+

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthorizedUser.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthorizedUser.java
@@ -1,0 +1,53 @@
+package nettee.jwt.annotation;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * JWT 토큰 내의 인증된 사용자 정보
+ */
+@Getter
+@Builder
+@ToString
+public class AuthorizedUser {
+    
+    /**
+     * 사용자 ID (JWT subject)
+     */
+    private final String userId;
+    
+    /**
+     * 사용자 권한 목록
+     */
+    private final List<String> roles;
+    
+    /**
+     * 사용자 프로필 ID 목록
+     */
+    private final List<String> profileIds;
+
+
+    // 사용자가 인증되었는지 확인
+    public boolean hasUserId() {
+        return userId != null && !userId.isEmpty();
+    }
+
+    // 사용자가 특정 역할을 가지고 있는지 확인
+    public boolean hasRoles(String role) {
+        if (roles == null || roles.isEmpty()){
+            return false;
+        }
+        return roles.contains(role);
+    }
+    
+    // 사용자가 특정 프로필 ID를 가지고 있는지 확인
+    public boolean hasProfileId(String profileId) {
+        if (profileIds == null || profileIds.isEmpty()) {
+            return false;
+        }
+        return profileIds.contains(profileId);
+    }
+}

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthorizedUser.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthorizedUser.java
@@ -1,34 +1,18 @@
 package nettee.jwt.annotation;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
-
 import java.util.List;
 
 /**
  * JWT 토큰 내의 인증된 사용자 정보
+ *
+ * @param userId     사용자 ID (JWT subject)
+ * @param roles      사용자 권한 목록
+ * @param profileIds 사용자 프로필 ID 목록
  */
-@Getter
-@Builder
-@ToString
-public class AuthorizedUser {
-    
-    /**
-     * 사용자 ID (JWT subject)
-     */
-    private final String userId;
-    
-    /**
-     * 사용자 권한 목록
-     */
-    private final List<String> roles;
-    
-    /**
-     * 사용자 프로필 ID 목록
-     */
-    private final List<String> profileIds;
-
+public record AuthorizedUser(
+        String userId,
+        List<String> roles,
+        List<String> profileIds) {
 
     // 사용자가 인증되었는지 확인
     public boolean hasUserId() {
@@ -37,12 +21,12 @@ public class AuthorizedUser {
 
     // 사용자가 특정 역할을 가지고 있는지 확인
     public boolean hasRoles(String role) {
-        if (roles == null || roles.isEmpty()){
+        if (roles == null || roles.isEmpty()) {
             return false;
         }
         return roles.contains(role);
     }
-    
+
     // 사용자가 특정 프로필 ID를 가지고 있는지 확인
     public boolean hasProfileId(String profileId) {
         if (profileIds == null || profileIds.isEmpty()) {

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthorizedUser.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/annotation/AuthorizedUser.java
@@ -14,6 +14,18 @@ public record AuthorizedUser(
         List<String> roles,
         List<String> profileIds) {
 
+    public AuthorizedUser {
+        if (userId == null) {
+            userId = "";
+        }
+        if (roles == null) {
+            roles = List.of();
+        }
+        if (profileIds == null) {
+            profileIds = List.of();
+        }
+    }
+
     // 사용자가 인증되었는지 확인
     public boolean hasUserId() {
         return userId != null && !userId.isEmpty();
@@ -21,17 +33,11 @@ public record AuthorizedUser(
 
     // 사용자가 특정 역할을 가지고 있는지 확인
     public boolean hasRoles(String role) {
-        if (roles == null || roles.isEmpty()) {
-            return false;
-        }
         return roles.contains(role);
     }
 
     // 사용자가 특정 프로필 ID를 가지고 있는지 확인
     public boolean hasProfileId(String profileId) {
-        if (profileIds == null || profileIds.isEmpty()) {
-            return false;
-        }
         return profileIds.contains(profileId);
     }
 }

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,124 @@
+package nettee.jwt.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nettee.jwt.JwtParser;
+import nettee.jwt.annotation.AuthorizedUser;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * JWT 인가 필터
+ * HTTP 요청에서 JWT 토큰을 추출하고 검증하여 인가를 처리합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtParser jwtParser;
+    private final JwtFilterConfig filterConfig;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                  HttpServletResponse response,
+                                  FilterChain filterChain) throws IOException, ServletException {
+        
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+        
+        // 1. Authorization 헤더에서 JWT 토큰 추출
+        String jwtToken = extractJwtToken(request);
+
+        // 2. JWT 토큰이 없으면 401 Unauthorized 응답
+        if (jwtToken == null) {
+            log.warn("JWT 토큰이 없습니다. [{}]: {}", method, requestURI);
+            sendUnauthorizedResponse(response, "JWT 토큰이 없습니다.", "Authorization 헤더에 JWT 토큰이 없습니다.");
+            return;
+        }
+
+        try {
+            // 3. JWT 토큰 검증 및 파싱
+            var claims = jwtParser.parseClaims(jwtToken);
+
+
+            // 4. JWT 토큰에서 사용자 정보 추출
+            // 런타임에 제네릭 타입 정보가 지워지면서, JWT Claim의 roles와 profileIds List 타입을 알 수가 없어 나오는 경고
+            // JWT 생성 시, List<String> 타입을 보장하기 때문에 @SuppressWarnings("unchecked") 사용
+            @SuppressWarnings("unchecked")
+            var authUser = AuthorizedUser.builder()
+                    .userId(claims.getSubject())
+                    .roles(Optional.ofNullable((List<String>) claims.get("roles", List.class))
+                            .orElse(Collections.emptyList()))
+                    .profileIds(Optional.ofNullable((List<String>) claims.get("profileIds", List.class))
+                            .orElse(Collections.emptyList()))
+                    .build();
+            request.setAttribute("authUser", authUser);
+
+            filterChain.doFilter(request, response);
+            
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT 토큰이 만료되었습니다.");
+            sendUnauthorizedResponse(response, "JWT 토큰이 만료되었습니다.", e.getMessage());
+
+        } catch (JwtException e) {
+            log.error("JWT 토큰이 유효하지 않습니다.");
+            sendUnauthorizedResponse(response, "JWT 토큰이 유효하지 않습니다.", e.getMessage());
+        }
+    }
+
+    /**
+     * JWT 토큰이 필요하지 않은 경로는 바로 통과
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        // 특정 조건에서 필터를 건너뛰고 싶은 경우 여기서 처리
+        return filterConfig.getExcludePaths().stream()
+                .anyMatch(requestURI::startsWith);
+    }
+
+    /**
+     * HTTP 요청의 Authorization 헤더에서 JWT 토큰을 추출합니다.
+     */
+    private String extractJwtToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith("Bearer ")) {
+            return null;
+        }
+
+        return authorizationHeader.substring(7); // "Bearer " 제거
+    }
+
+    /**
+     * 401 Unauthorized 응답을 전송합니다.
+     */
+    private void sendUnauthorizedResponse(HttpServletResponse response, String error, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String responseBody = String.format("""
+            {
+                "error": "%s",
+                "message": "%s",
+                "timestamp": "%s"
+            }
+            """, error, message, Instant.now());
+
+        response.getWriter().write(responseBody);
+    }
+}

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -8,13 +8,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nettee.jwt.JwtParser;
-import nettee.jwt.annotation.AuthorizedUser;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -53,22 +50,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             // 3. JWT 토큰 검증 및 파싱
             var claims = jwtParser.parseClaims(jwtToken);
 
-
             // 4. JWT 토큰에서 사용자 정보 추출
-            // 런타임에 제네릭 타입 정보가 지워지면서, JWT Claim의 roles와 profileIds List 타입을 알 수가 없어 나오는 경고
-            // JWT 생성 시, List<String> 타입을 보장하기 때문에 @SuppressWarnings("unchecked") 사용
-            @SuppressWarnings("unchecked")
-            var authUser = AuthorizedUser.builder()
-                    .userId(claims.getSubject())
-                    .roles(Optional.ofNullable((List<String>) claims.get("roles", List.class))
-                            .orElse(Collections.emptyList()))
-                    .profileIds(Optional.ofNullable((List<String>) claims.get("profileIds", List.class))
-                            .orElse(Collections.emptyList()))
-                    .build();
-            request.setAttribute("authUser", authUser);
+            request.setAttribute("userId", claims.getSubject());
+            request.setAttribute("roles", claims.get("roles", List.class));
+            request.setAttribute("profileIds", claims.get("profileIds", List.class));
 
             filterChain.doFilter(request, response);
-            
         } catch (ExpiredJwtException e) {
             log.warn("JWT 토큰이 만료되었습니다.");
             sendUnauthorizedResponse(response, "JWT 토큰이 만료되었습니다.", e.getMessage());

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -73,8 +73,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
 
-        return filterConfig.getExcludePaths().stream()
-                .anyMatch(requestURI::startsWith);
+        return filterConfig.getExcludePaths().contains(requestURI);
     }
 
     /**

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -44,8 +44,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         // 2. JWT 토큰이 없으면 401 Unauthorized 응답
         if (jwtToken == null) {
-            log.warn("JWT 토큰이 없습니다. [{}]: {}", method, requestURI);
-            sendUnauthorizedResponse(response, "JWT 토큰이 없습니다.", "Authorization 헤더에 JWT 토큰이 없습니다.");
+            log.warn("JWT 토큰이 존재하지 않습니다. [{}]: {}", method, requestURI);
+            sendUnauthorizedResponse(response, "JWT 토큰이 존재하지 않습니다.", "Authorization 헤더에 JWT 토큰이 존재하지 않습니다.");
             return;
         }
 
@@ -85,7 +85,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
-        // 특정 조건에서 필터를 건너뛰고 싶은 경우 여기서 처리
+
         return filterConfig.getExcludePaths().stream()
                 .anyMatch(requestURI::startsWith);
     }

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import nettee.jwt.JwtParser;
+import nettee.jwt.parser.JwtParser;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
@@ -2,22 +2,19 @@ package nettee.jwt.filter;
 
 import java.util.Set;
 import lombok.Getter;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
 @Getter
-@Component
+@Configuration
+@ConfigurationProperties(prefix = "blolet.jwt.filter")
 public class JwtFilterConfig {
-    
     /**
      * JWT 토큰 검증이 필요하지 않은 경로들
      */
-    private final Set<String> excludePaths = Set.of(
-        "/auth/signup",
-        "/auth/login",
-        "/auth/email/verification/send",
-        "/auth/email/verification/check",
-        "/auth/token/refresh",
-        "/swagger-ui"
-    );
-}
+    private Set<String> excludePaths = Set.of();
 
+    public void setExcludePaths(Set<String> excludePaths) {
+        this.excludePaths = (excludePaths == null) ? Set.of() : Set.copyOf(excludePaths);
+    }
+}

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
@@ -1,0 +1,23 @@
+package nettee.jwt.filter;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtFilterConfig {
+    
+    /**
+     * JWT 토큰 검증이 필요하지 않은 경로들
+     */
+    private final List<String> excludePaths = List.of(
+        "/auth/signup",
+        "/auth/login",
+        "/auth/email/verification/send",
+        "/auth/email/verification/check",
+        "/auth/token/refresh",
+        "/swagger-ui"
+    );
+}
+

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Getter
 @Configuration
-@ConfigurationProperties(prefix = "blolet.jwt.filter")
+@ConfigurationProperties(prefix = "blolet.jwt.filter.exclude-paths")
 public class JwtFilterConfig {
     /**
      * JWT 토큰 검증이 필요하지 않은 경로들

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtFilterConfig.java
@@ -1,6 +1,6 @@
 package nettee.jwt.filter;
 
-import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +11,7 @@ public class JwtFilterConfig {
     /**
      * JWT 토큰 검증이 필요하지 않은 경로들
      */
-    private final List<String> excludePaths = List.of(
+    private final Set<String> excludePaths = Set.of(
         "/auth/signup",
         "/auth/login",
         "/auth/email/verification/send",

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
@@ -34,8 +34,8 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         String userId = (String) request.getAttribute("userId");
-        List<String> roles = (List<String>) request.getAttribute("roles");
-        List<String> profileIds = (List<String>) request.getAttribute("profileIds");
+        @SuppressWarnings("unchecked") List<String> roles = (List<String>) request.getAttribute("roles");
+        @SuppressWarnings("unchecked") List<String> profileIds = (List<String>) request.getAttribute("profileIds");
 
         return new AuthorizedUser(userId, roles, profileIds);
     }

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
@@ -13,7 +13,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
- * @AuthUser 어노테이션이 붙은 파라미터를 처리하여 AuthenticatedUser 객체를 주입하는 ArgumentResolver
+ * @AuthUser 어노테이션이 붙은 파라미터를 처리하여 AuthorizedUser 객체를 주입하는 ArgumentResolver
  */
 @Component
 @RequiredArgsConstructor

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
@@ -1,6 +1,7 @@
 package nettee.jwt.resolver;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import nettee.jwt.annotation.AuthUser;
 import nettee.jwt.annotation.AuthorizedUser;
@@ -31,7 +32,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
                                   WebDataBinderFactory binderFactory) {
 
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        return (AuthorizedUser) request.getAttribute("authUser");
+
+        String userId = (String) request.getAttribute("userId");
+        List<String> roles = (List<String>) request.getAttribute("roles");
+        List<String> profileIds = (List<String>) request.getAttribute("profileIds");
+
+        return new AuthorizedUser(userId, roles, profileIds);
     }
 }
 

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,37 @@
+package nettee.jwt.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import nettee.jwt.annotation.AuthUser;
+import nettee.jwt.annotation.AuthorizedUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @AuthUser 어노테이션이 붙은 파라미터를 처리하여 AuthenticatedUser 객체를 주입하는 ArgumentResolver
+ */
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class)
+                && parameter.getParameterType().equals(AuthorizedUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return (AuthorizedUser) request.getAttribute("authUser");
+    }
+}
+

--- a/core/security/jwt/jwt-issuer/src/main/java/nettee/jwt/issuer/JwtIssuer.java
+++ b/core/security/jwt/jwt-issuer/src/main/java/nettee/jwt/issuer/JwtIssuer.java
@@ -1,4 +1,4 @@
-package nettee.jwt;
+package nettee.jwt.issuer;
 
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;

--- a/core/security/jwt/jwt-issuer/src/main/java/nettee/jwt/issuer/JwtIssuerConfig.java
+++ b/core/security/jwt/jwt-issuer/src/main/java/nettee/jwt/issuer/JwtIssuerConfig.java
@@ -1,12 +1,13 @@
-package nettee.jwt;
+package nettee.jwt.issuer;
 
+import nettee.jwt.JwtProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
-public class JwtConfig {
+public class JwtIssuerConfig {
 
     @Bean
     public JwtIssuer jwtIssuer(JwtProperties properties) {

--- a/core/security/jwt/jwt-issuer/src/test/kotlin/nettee/jwt/JwtIssuerTest.kt
+++ b/core/security/jwt/jwt-issuer/src/test/kotlin/nettee/jwt/JwtIssuerTest.kt
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
+import nettee.jwt.issuer.JwtIssuer
 import java.security.KeyPairGenerator
 import java.security.SecureRandom
 import java.util.*

--- a/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/JwtParser.java
+++ b/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/JwtParser.java
@@ -1,4 +1,4 @@
-package nettee.jwt;
+package nettee.jwt.parser;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;

--- a/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/JwtParserConfig.java
+++ b/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/JwtParserConfig.java
@@ -1,12 +1,13 @@
-package nettee.jwt;
+package nettee.jwt.parser;
 
+import nettee.jwt.JwtProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
-public class JwtConfig {
+public class JwtParserConfig {
 
     @Bean
     public JwtParser jwtParser(JwtProperties properties) {

--- a/core/security/jwt/jwt-parser/src/test/kotlin/nettee/jwt/JwtParserTest.kt
+++ b/core/security/jwt/jwt-parser/src/test/kotlin/nettee/jwt/JwtParserTest.kt
@@ -4,6 +4,8 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.jsonwebtoken.Claims
+import nettee.jwt.issuer.JwtIssuer
+import nettee.jwt.parser.JwtParser
 import java.security.KeyPairGenerator
 import java.util.*
 

--- a/monolith/main-runner/build.gradle.kts
+++ b/monolith/main-runner/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":jpa-core"))
     implementation(project(":cors-webmvc"))
     implementation(project(":rest-client"))
+    implementation(project(":security-blolet-jwt-filter"))
 
     // service
     api(project(series))

--- a/monolith/main-runner/src/main/java/nettee/main/config/WebConfig.java
+++ b/monolith/main-runner/src/main/java/nettee/main/config/WebConfig.java
@@ -1,0 +1,23 @@
+package nettee.main.config;
+
+import lombok.RequiredArgsConstructor;
+import nettee.jwt.resolver.AuthUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        // AuthUserArgumentResolver 추가하여 @AuthUser 어노테이션을 처리할 수 있도록 설정
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/monolith/main-runner/src/main/resources/application.yml
+++ b/monolith/main-runner/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
       - properties/persistence/main.snowflake.yml
       - properties/client/main.client.yml
       - properties/jwt/main.jwt.yml
+      - properties/jwt/blolet.jwt.filter.yml
       - properties/mail/main.mail.yml
       - optional:file:.env[.properties]
 

--- a/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
+++ b/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
@@ -1,0 +1,10 @@
+blolet:
+  jwt:
+    filter:
+      exclude-paths:
+        - /auth/signup
+        - /auth/login
+        - /auth/email/verification/send
+        - /auth/email/verification/check
+        - /auth/token/refresh
+        - /swagger-ui

--- a/monolith/main-runner/src/main/resources/properties/jwt/main.jwt-local.yml
+++ b/monolith/main-runner/src/main/resources/properties/jwt/main.jwt-local.yml
@@ -1,0 +1,5 @@
+jwt:
+  keyType: "HMAC"
+  secretKey: ${JWT_SECRET_KEY:bmV0dGVlLWJsb2xldC1qd3Qtc2VjcmV0LWtleS1leHRlbmQ}
+  accessTokenMaxAgeSeconds: 1_800       # 30 minutes
+  refreshTokenMaxAgeSeconds: 1_209_600  # 14 days

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -28,7 +28,7 @@ import nettee.auth.port.MailSender;
 import nettee.auth.usecase.AuthSignUsecase;
 import nettee.blolet.auth.readmodel.AuthCommandModels.LoginTokenModel;
 import nettee.blolet.auth.readmodel.AuthCommandModels.SignUpRequestModel;
-import nettee.jwt.JwtIssuer;
+import nettee.jwt.issuer.JwtIssuer;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
## Issues

- Resolves #238

## Description

- 블로렛 서비스 JWT 인가 필터 구현
- 커스텀 어노테이션 + Argument Resolver 방식으로 인가 유저의 정보 관리
  - `@AuthUser`: 클라이언트 요청에 포함된 jwt 인가 정보를 AuthorizedUser 객체로 변환시켜주는 트리거 역할
  - `AuthorizedUser`: jwt 인가 정보를 담고 있는 객체

<br />

## Review Points

- `@AuthUser`와 `AuthorizedUser` 관련해서 좋은 네이밍이 생각나시면 추천 부탁드립니다!

<br />

## How Has This Been Tested?

- 테스트는 추가로 올리겠습니다..!! (테스트 작성이 어렵네요😭)

<br />

## Additional Notes

- 필터 + 리졸버 / 어노테이션 + 인가 객체 모듈 분리를 고민했습니다. 현재는 모놀리스라서 각 도메인에서 웹 요청과 같은 설정 정보를 관리하지 않아 의미가 있을 수 있겠지만, 이후 MSA와 같이 각 도메인에서 설정 정보를 관리해야 하므로 하나의 모듈로 관리하는 것이 좋을 것 같아 이와 같이 설계했습니다.
