### PR TITLE
Common > Preconditions: 숫자 타입 입력값이 올바른 범위에 있는지 검토합니다. (상하한 바운더리)

### DIFF
--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -494,6 +494,79 @@ public final class Preconditions {
         }
     }
 
+    // ╭──────────────────────────────────────╮
+    //    number types: validateMax variants
+    // ╰──────────────────────────────────────╯
+
+
+    public static void validateMax(
+            double value,
+            double max,
+            ErrorCode errorCode
+    ) {
+        if (value > max) {
+            throw errorCode.exception();
+        }
+    }
+
+    public static void validateMax(
+            double value,
+            double max,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        if (value > max) {
+            throw errorCode.exception(cause);
+        }
+    }
+
+    public static void validateMax(
+            double value,
+            double max,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        if (value > max) {
+            throw errorCode.exception(runnable);
+        }
+    }
+
+    public static void validateMiax(
+            double value,
+            double max,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        if (value > max) {
+            throw errorCode.exception(runnable, cause);
+        }
+    }
+
+    public static void validateMax(
+            double value,
+            double max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        if (value > max) {
+            throw errorCode.exception(payloadSupplier);
+        }
+    }
+
+    public static void validateMax(
+            double value,
+            double max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        if (value > max) {
+            throw errorCode.exception(payloadSupplier, cause);
+        }
+    }
+
+
     // ╭────────────────────────────────╮
     //    String: validateMin variants
     // ╰────────────────────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -422,6 +422,78 @@ public final class Preconditions {
         performMinMaxValidation(value, min, max, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭──────────────────────────────────────╮
+    //    number types: validateMin variants
+    // ╰──────────────────────────────────────╯
+
+
+    public static void validateMin(
+            double value,
+            double min,
+            ErrorCode errorCode
+    ) {
+        if (value < min) {
+            throw errorCode.exception();
+        }
+    }
+
+    public static void validateMin(
+            double value,
+            double min,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        if (value < min) {
+            throw errorCode.exception(cause);
+        }
+    }
+
+    public static void validateMin(
+            double value,
+            double min,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        if (value < min) {
+            throw errorCode.exception(runnable);
+        }
+    }
+
+    public static void validateMinM(
+            double value,
+            double min,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        if (value < min) {
+            throw errorCode.exception(runnable, cause);
+        }
+    }
+
+    public static void validateMin(
+            double value,
+            double min,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        if (value < min) {
+            throw errorCode.exception(payloadSupplier);
+        }
+    }
+
+    public static void validateMin(
+            double value,
+            double min,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        if (value < min) {
+            throw errorCode.exception(payloadSupplier, cause);
+        }
+    }
+
     // ╭────────────────────────────────╮
     //    String: validateMin variants
     // ╰────────────────────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -357,6 +357,71 @@ public final class Preconditions {
         performLengthValidation(collection, min, max, () -> errorCode.exception(payloadSupplier, cause));
     }
 
+    // ╭──────────────────────────────────────────╮
+    //    numeric types: validateMinMax variants
+    // ╰──────────────────────────────────────────╯
+
+    public static void validateMinMax(
+            double value,
+            double min,
+            double max,
+            ErrorCode errorCode
+    ) {
+        performMinMaxValidation(value, min, max, errorCode::exception);
+    }
+
+    public static void validateMinMax(
+            double value,
+            double min,
+            double max,
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        performMinMaxValidation(value, min, max, () -> errorCode.exception(cause));
+    }
+
+    public static void validateMinMax(
+            double value,
+            double min,
+            double max,
+            ErrorCode errorCode,
+            Runnable runnable
+    ) {
+        performMinMaxValidation(value, min, max, () -> errorCode.exception(runnable));
+    }
+
+    public static void validateMinMax(
+            double value,
+            double min,
+            double max,
+            ErrorCode errorCode,
+            Runnable runnable,
+            Throwable cause
+    ) {
+        performMinMaxValidation(value, min, max, () -> errorCode.exception(runnable, cause));
+    }
+
+    public static void validateMinMax(
+            double value,
+            double min,
+            double max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier
+    ) {
+        performMinMaxValidation(value, min, max, () -> errorCode.exception(payloadSupplier));
+    }
+
+    public static void validateMinMax(
+            double value,
+            double min,
+            double max,
+            ErrorCode errorCode,
+            Supplier<Map<String, Object>> payloadSupplier,
+            Throwable cause
+    ) {
+        performMinMaxValidation(value, min, max, () -> errorCode.exception(payloadSupplier, cause));
+    }
+
     // ╭────────────────────────────────╮
     //    String: validateMin variants
     // ╰────────────────────────────────╯

--- a/common/src/main/java/nettee/common/validation/Preconditions.java
+++ b/common/src/main/java/nettee/common/validation/Preconditions.java
@@ -717,6 +717,20 @@ public final class Preconditions {
         }
     }
 
+    private static void performMinMaxValidation(
+            double value,
+            double min,
+            double max,
+            Supplier<? extends RuntimeException> exceptionSupplier
+    ) {
+        assert min >= 0 && max >= 0 : "min, max cannot be less than or equal to 0";
+        assert min < max : "max must be greater than or equal to " + min;
+
+        if (value < min || value > max) {
+            throw exceptionSupplier.get();
+        }
+    }
+
     private static void performMinValidation(
             String value,
             int min,

--- a/common/src/main/java/nettee/common/validation/README.md
+++ b/common/src/main/java/nettee/common/validation/README.md
@@ -67,32 +67,32 @@ public final class BlogValidator {
 
     public static void validate(BlogValidationTarget field, Object value) {
         switch (field) {
-            case ID ->
+            case BLOG_ID ->
                     validateNotNull(value, BLOG_ID_REQUIRED);
-            case USER_ID -> {
+            case BLOG_USER_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
             }
-            case PROFILE_ID -> {
+            case BLOG_PROFILE_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
             }
-            case USERNAME -> {
+            case BLOG_USERNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_USERNAME_REQUIRED);
             }
-            case NICKNAME -> {
+            case BLOG_NICKNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
             }
-            case NAME -> {
+            case BLOG_NAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NAME_REQUIRED);
 
                 str = str.strip();
                 validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
             }
-            case URL_IDENTIFIER -> {
+            case BLOG_URL_IDENTIFIER -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_URL_REQUIRED);
 
@@ -114,13 +114,13 @@ public final class BlogValidator {
     }
 
     public enum BlogValidationTarget {
-        ID,
-        USER_ID,
-        PROFILE_ID,
-        NAME,
-        URL_IDENTIFIER,
-        USERNAME,
-        NICKNAME
+        BLOG_ID,
+        BLOG_USER_ID,
+        BLOG_PROFILE_ID,
+        BLOG_NAME,
+        BLOG_URL_IDENTIFIER,
+        BLOG_USERNAME,
+        BLOG_NICKNAME
     }
 }
 ```
@@ -194,32 +194,32 @@ public final class BlogValidator {
 
     public static void validate(BlogValidationTarget field, Object value) {
         switch (field) {
-            case ID ->
+            case BLOG_ID ->
                     validateNotNull(value, BLOG_ID_REQUIRED);
-            case USER_ID -> {
+            case BLOG_USER_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
             }
-            case PROFILE_ID -> {
+            case BLOG_PROFILE_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
             }
-            case USERNAME -> {
+            case BLOG_USERNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_USERNAME_REQUIRED);
             }
-            case NICKNAME -> {
+            case BLOG_NICKNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
             }
-            case NAME -> {
+            case BLOG_NAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NAME_REQUIRED);
 
                 str = str.strip();
                 validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
             }
-            case URL_IDENTIFIER -> {
+            case BLOG_URL_IDENTIFIER -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_URL_REQUIRED);
 
@@ -241,13 +241,13 @@ public final class BlogValidator {
     }
 
     public enum BlogValidationTarget {
-        ID,
-        USER_ID,
-        PROFILE_ID,
-        NAME,
-        URL_IDENTIFIER,
-        USERNAME,
-        NICKNAME
+        BLOG_ID,
+        BLOG_USER_ID,
+        BLOG_PROFILE_ID,
+        BLOG_NAME,
+        BLOG_URL_IDENTIFIER,
+        BLOG_USERNAME,
+        BLOG_NICKNAME
     }
 }
 ```
@@ -321,32 +321,32 @@ public final class BlogValidator {
 
     public static void validate(BlogValidationTarget field, Object value) {
         switch (field) {
-            case ID ->
+            case BLOG_ID ->
                     validateNotNull(value, BLOG_ID_REQUIRED);
-            case USER_ID -> {
+            case BLOG_USER_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
             }
-            case PROFILE_ID -> {
+            case BLOG_PROFILE_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
             }
-            case USERNAME -> {
+            case BLOG_USERNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_USERNAME_REQUIRED);
             }
-            case NICKNAME -> {
+            case BLOG_NICKNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
             }
-            case NAME -> {
+            case BLOG_NAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NAME_REQUIRED);
 
                 str = str.strip();
                 validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
             }
-            case URL_IDENTIFIER -> {
+            case BLOG_URL_IDENTIFIER -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_URL_REQUIRED);
 
@@ -368,13 +368,13 @@ public final class BlogValidator {
     }
 
     public enum BlogValidationTarget {
-        ID,
-        USER_ID,
-        PROFILE_ID,
-        NAME,
-        URL_IDENTIFIER,
-        USERNAME,
-        NICKNAME
+        BLOG_ID,
+        BLOG_USER_ID,
+        BLOG_PROFILE_ID,
+        BLOG_NAME,
+        BLOG_URL_IDENTIFIER,
+        BLOG_USERNAME,
+        BLOG_NICKNAME
     }
 }
 ```

--- a/common/src/main/java/nettee/common/validation/README.md
+++ b/common/src/main/java/nettee/common/validation/README.md
@@ -1,0 +1,145 @@
+<br />
+
+---
+<a id="ko"></a>
+
+- ▶⠀⠀Korean
+- ⠀⠀⠀[English](#en)
+- ⠀⠀⠀[Japanese](#ja)
+
+> Last updated at: 2025-08-14
+
+# 유효성 체크
+
+- `Preconditions`: 사전조건을 검토합니다. 네이밍과 달리 사후조건 체크로 활용할 수도 있습니다.
+
+## 지원 기능
+
+**지원 대상 타입**
+
+- `Object`: `validateNotNull`
+- `String`: `validateNotNull`, `validateNotEmpty`, `validateNotBlank`, `validateLength`, `validateMin`, `validateMax`,  
+  `validateRegex`
+- `Collection`: `validateNotNull`, `validateNotEmpty`, `validateLength`, `validateMin`, `validateMax`
+- Number types (`≤ 8 Bytes`): `validateMinMax`, `validateMin`, `validateMax`
+
+### 간단한 예시
+
+- 본 프로젝트는 유효성 관련 정적 메서드의 static import를 허용하므로 예시를 보실 때 참고 부탁드립니다.
+
+```java
+// 콤팩트 생성자에서 유효성을 체크하는 예시
+public Example {
+    // [1] 공백 검증: `title`은 `null`, `""`, `" "` 등 공백만 있거나 비어 있으면 안 됩니다.
+    validateNotBlank(title, TITLE_REQUIRED);
+    
+    // [2] 전처리: `title`의 앞뒤 공백을 절삭한 다음 유효성 검증을 이어갈 수도 있습니다.
+    title = title.strip();
+
+    // [3] 길이 검증: `title`의 길이는 3 이상 100 이하여야 합니다.
+    validateMin(title, 3, TITLE_TOO_SHORT);
+    validateMax(title, 100, TITLE_TOO_LONG);
+}
+```
+
+### 제안 구조
+
+```java
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_INPUT_TYPE_MISMATCHED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NICKNAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_PROFILE_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_FORMAT;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_USERNAME_REQUIRED;
+import static nettee.common.validation.Preconditions.validateLength;
+import static nettee.common.validation.Preconditions.validateNotBlank;
+import static nettee.common.validation.Preconditions.validateNotNull;
+import static nettee.common.validation.Preconditions.validateRegex;
+
+public final class BlogValidator {
+
+    private BlogValidator() {}
+
+    public static void validate(BlogValidationTarget field, Object value) {
+        switch (field) {
+            case ID ->
+                    validateNotNull(value, BLOG_ID_REQUIRED);
+            case USER_ID -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
+            }
+            case PROFILE_ID -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
+            }
+            case USERNAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_USERNAME_REQUIRED);
+            }
+            case NICKNAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
+            }
+            case NAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_NAME_REQUIRED);
+
+                str = str.strip();
+                validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
+            }
+            case URL_IDENTIFIER -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_URL_REQUIRED);
+
+                str = str.strip();
+                validateRegex(str, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
+                validateLength(str, 3, 15, BLOG_URL_INVALID_LENGTH);
+            }
+        }
+    }
+
+    private static String castToString(Object value) {
+        if (value == null) return null;
+
+        if (!(value instanceof String str)) {
+            throw BLOG_INPUT_TYPE_MISMATCHED.exception();
+        }
+
+        return str;
+    }
+
+    public enum BlogValidationTarget {
+        ID,
+        USER_ID,
+        PROFILE_ID,
+        NAME,
+        URL_IDENTIFIER,
+        USERNAME,
+        NICKNAME
+    }
+}
+```
+
+<br />
+
+---
+<a id="en"></a>
+
+- ⠀⠀⠀[Korean](#ko)
+- ▶⠀⠀English
+- ⠀⠀⠀[Japanese](#ja)
+
+<br />
+
+---
+<a id="ja"></a>
+
+- ⠀⠀⠀[Korean](#ko)
+- ⠀⠀⠀[English](#en)
+- ▶⠀⠀Japanese
+

--- a/common/src/main/java/nettee/common/validation/README.md
+++ b/common/src/main/java/nettee/common/validation/README.md
@@ -261,3 +261,120 @@ public final class BlogValidator {
 - ⠀⠀⠀[English](#en)
 - ▶⠀⠀Japanese
 
+> 最終更新: 2025-08-14 午前7:00
+
+# バリデーション
+
+- `Preconditions`: 前提条件を検証します。命名に反して、事後条件のチェックとしても利用できます。
+
+## 対応機能
+
+**サポート対象の型**
+
+- `Object`: `validateNotNull`
+- `String`: `validateNotNull`, `validateNotEmpty`, `validateNotBlank`, `validateLength`, `validateMin`, `validateMax`,  
+  `validateRegex`
+- `Collection`: `validateNotNull`, `validateNotEmpty`, `validateLength`, `validateMin`, `validateMax`
+- 数値型（8バイト以下）: `validateMinMax`, `validateMin`, `validateMax`
+
+### 簡単な例
+
+- 本プロジェクトではバリデーション関連の静的メソッドの static import を許可しているため、以下の例では static import を前提としています。
+
+```java
+// コンパクトコンストラクタでバリデーションを行う例
+public Example {
+    // [1] 空白検証: `title` は `null`、`""`、`" "` など空白のみ、または空の場合にはできません。
+    validateNotBlank(title, TITLE_REQUIRED);
+    
+    // [2] 前処理: `title` の前後の空白を除去してからバリデーションを続けられます。
+    title = title.strip();
+
+    // [3] 長さ検証: `title` の長さは 3 以上 100 以下である必要があります。
+    validateMin(title, 3, TITLE_TOO_SHORT);
+    validateMax(title, 100, TITLE_TOO_LONG);
+}
+```
+
+### 推奨構成
+
+```java
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_INPUT_TYPE_MISMATCHED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NICKNAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_PROFILE_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_FORMAT;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_USERNAME_REQUIRED;
+import static nettee.common.validation.Preconditions.validateLength;
+import static nettee.common.validation.Preconditions.validateNotBlank;
+import static nettee.common.validation.Preconditions.validateNotNull;
+import static nettee.common.validation.Preconditions.validateRegex;
+
+public final class BlogValidator {
+
+    private BlogValidator() {}
+
+    public static void validate(BlogValidationTarget field, Object value) {
+        switch (field) {
+            case ID ->
+                    validateNotNull(value, BLOG_ID_REQUIRED);
+            case USER_ID -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
+            }
+            case PROFILE_ID -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
+            }
+            case USERNAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_USERNAME_REQUIRED);
+            }
+            case NICKNAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
+            }
+            case NAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_NAME_REQUIRED);
+
+                str = str.strip();
+                validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
+            }
+            case URL_IDENTIFIER -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_URL_REQUIRED);
+
+                str = str.strip();
+                validateRegex(str, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
+                validateLength(str, 3, 15, BLOG_URL_INVALID_LENGTH);
+            }
+        }
+    }
+
+    private static String castToString(Object value) {
+        if (value == null) return null;
+
+        if (!(value instanceof String str)) {
+            throw BLOG_INPUT_TYPE_MISMATCHED.exception();
+        }
+
+        return str;
+    }
+
+    public enum BlogValidationTarget {
+        ID,
+        USER_ID,
+        PROFILE_ID,
+        NAME,
+        URL_IDENTIFIER,
+        USERNAME,
+        NICKNAME
+    }
+}
+```

--- a/common/src/main/java/nettee/common/validation/README.md
+++ b/common/src/main/java/nettee/common/validation/README.md
@@ -134,6 +134,124 @@ public final class BlogValidator {
 - ▶⠀⠀English
 - ⠀⠀⠀[Japanese](#ja)
 
+> Last updated: 2025-08-14 07:00 AM
+
+# Validation
+
+- `Preconditions`: Validate preconditions. Despite the name, it can also be used for postcondition checks.
+
+## Supported Features
+
+**Supported Target Types**
+
+- `Object`: `validateNotNull`
+- `String`: `validateNotNull`, `validateNotEmpty`, `validateNotBlank`, `validateLength`, `validateMin`, `validateMax`,  
+  `validateRegex`
+- `Collection`: `validateNotNull`, `validateNotEmpty`, `validateLength`, `validateMin`, `validateMax`
+- Number types (`≤ 8 Bytes`): `validateMinMax`, `validateMin`, `validateMax`
+
+### Quick Example
+
+- This project allows static imports of validation-related methods; please keep that in mind when reading the examples.
+
+```java
+// Example: validating inside a compact constructor
+public Example {
+    // [1] Whitespace check: `title` must not be `null`, `""`, or consist only of whitespace such as `" "`.
+    validateNotBlank(title, TITLE_REQUIRED);
+    
+    // [2] Preprocessing: You may trim leading and trailing whitespace from `title` and then continue validation.
+    title = title.strip();
+
+    // [3] Length check: the length of `title` must be between 3 and 100 (inclusive).
+    validateMin(title, 3, TITLE_TOO_SHORT);
+    validateMax(title, 100, TITLE_TOO_LONG);
+}
+```
+
+### Proposed Structure
+
+```java
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_INPUT_TYPE_MISMATCHED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NICKNAME_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_PROFILE_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_FORMAT;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_LENGTH;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_USERNAME_REQUIRED;
+import static nettee.common.validation.Preconditions.validateLength;
+import static nettee.common.validation.Preconditions.validateNotBlank;
+import static nettee.common.validation.Preconditions.validateNotNull;
+import static nettee.common.validation.Preconditions.validateRegex;
+
+public final class BlogValidator {
+
+    private BlogValidator() {}
+
+    public static void validate(BlogValidationTarget field, Object value) {
+        switch (field) {
+            case ID ->
+                    validateNotNull(value, BLOG_ID_REQUIRED);
+            case USER_ID -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
+            }
+            case PROFILE_ID -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
+            }
+            case USERNAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_USERNAME_REQUIRED);
+            }
+            case NICKNAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
+            }
+            case NAME -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_NAME_REQUIRED);
+
+                str = str.strip();
+                validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
+            }
+            case URL_IDENTIFIER -> {
+                String str = castToString(value);
+                validateNotBlank(str, BLOG_URL_REQUIRED);
+
+                str = str.strip();
+                validateRegex(str, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
+                validateLength(str, 3, 15, BLOG_URL_INVALID_LENGTH);
+            }
+        }
+    }
+
+    private static String castToString(Object value) {
+        if (value == null) return null;
+
+        if (!(value instanceof String str)) {
+            throw BLOG_INPUT_TYPE_MISMATCHED.exception();
+        }
+
+        return str;
+    }
+
+    public enum BlogValidationTarget {
+        ID,
+        USER_ID,
+        PROFILE_ID,
+        NAME,
+        URL_IDENTIFIER,
+        USERNAME,
+        NICKNAME
+    }
+}
+```
+
 <br />
 
 ---

--- a/common/src/main/java/nettee/common/validation/README.md
+++ b/common/src/main/java/nettee/common/validation/README.md
@@ -125,6 +125,21 @@ public final class BlogValidator {
 }
 ```
 
+```java
+@Builder
+public record BlogUpdateCommand(
+        @Schema(description = "블로그 이름", example = "Sun☀️ Moon🌙")
+        String name,
+        @Schema(description = "블로그 주소 식별자", example = "wch-os")
+        String urlIdentifier
+) {
+    public BlogUpdateCommand {
+        validate(NAME, name);
+        validate(URL_IDENTIFIER, urlIdentifier);
+    }
+}
+```
+
 <br />
 
 ---
@@ -252,6 +267,21 @@ public final class BlogValidator {
 }
 ```
 
+```java
+@Builder
+public record BlogUpdateCommand(
+        @Schema(description = "Blog name", example = "Sun☀️ Moon🌙")
+        String name,
+        @Schema(description = "Blog URL identifier", example = "wch-os")
+        String urlIdentifier
+) {
+    public BlogUpdateCommand {
+        validate(NAME, name);
+        validate(URL_IDENTIFIER, urlIdentifier);
+    }
+}
+```
+
 <br />
 
 ---
@@ -375,6 +405,21 @@ public final class BlogValidator {
         BLOG_URL_IDENTIFIER,
         BLOG_USERNAME,
         BLOG_NICKNAME
+    }
+}
+```
+
+```java
+@Builder
+public record BlogUpdateCommand(
+        @Schema(description = "ブログ名", example = "Sun☀️ Moon🌙")
+        String name,
+        @Schema(description = "ブログのURL識別子", example = "wch-os")
+        String urlIdentifier
+) {
+    public BlogUpdateCommand {
+        validate(NAME, name);
+        validate(URL_IDENTIFIER, urlIdentifier);
     }
 }
 ```


### PR DESCRIPTION
## Issues

- Resolves #249 
  - Resolves #251 
  - Resolves #252 
  - Resolves #253 
- Resolves #250 

## Description

- Numeric 타입(`int`, `double` 등)의 값 범위를 검토하는 유틸리티 메서드를 추가합니다.
  - `validateMinMax`
  - `validateMin`
  - `validateMax`
- `Preconditions` 패키지를 설명하는 리드미 문서를 추가합니다.
  - 한국어 문서를 제공합니다.
  - ChatGPT-5로 영문, 일본어를 함께 제공합니다. (간단한 작업이라서 추가했습니다.)

<br />

## Review Points

- 비슷한 작업의 반복이지만 전체 항목이 많아 세세한 리뷰가 어려워 보입니다.  
  : 대략적으로 큰 문제가 발견되지 않으면 병합하고, 사소한 실수는 나중에 수정해도 좋을 것 같다는 생각입니다.

<br />

## How Has This Been Tested?

- **테스트 생략**: 유틸리티는 테스트 코드를 잘 제공하면 좋지만, 다음 작업이 많아 생략했습니다.
- 테스트코드는 추후에 추가하면 좋아 보입니다.

<br />

## Additional Notes

- 유효성 체크를 쉽게 커스텀할 수 있도록 메서드를 추가했습니다.
