### PR TITLE
Blog > Application: `BlogValidator`에서 타깃 열거상수에 "BLOG_" 접두사를 추가하고, 정적 임포트로 가독성 개선

### DIFF
--- a/services/blog/api/exception/src/main/java/nettee/blolet/blog/exception/BlogErrorCode.java
+++ b/services/blog/api/exception/src/main/java/nettee/blolet/blog/exception/BlogErrorCode.java
@@ -39,6 +39,8 @@ public enum BlogErrorCode implements ErrorCode {
     ALREADY_SUBSCRIBED_BLOG_NEWSLETTER("이미 뉴스레터를 구독하였습니다.", HttpStatus.CONFLICT),
     UNSUBSCRIBED_BLOG_NEWSLETTER("이미 구독 취소하거나 아직 구독하지 않은 뉴스레터입니다.", HttpStatus.CONFLICT),
 
+    BLOG_INPUT_TYPE_MISMATCHED(
+        "입력값의 타입 불일치가 발생했습니다. 문제가 지속되면 고객센터에 문의해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     DEFAULT("블로그 API 오류", HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/validation/BlogValidator.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/validation/BlogValidator.java
@@ -21,24 +21,24 @@ public final class BlogValidator {
 
     public static void validate(BlogValidationTarget field, Object value) {
         switch (field) {
-            case ID ->
+            case BLOG_ID ->
                 validateNotNull(value, BLOG_ID_REQUIRED);
-            case USER_ID -> {
+            case BLOG_USER_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_OWNER_ID_REQUIRED);
             }
-            case PROFILE_ID -> {
+            case BLOG_PROFILE_ID -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_PROFILE_ID_REQUIRED);
             }
-            case NAME -> {
+            case BLOG_NAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NAME_REQUIRED);
 
                 str = str.strip();
                 validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
             }
-            case URL_IDENTIFIER -> {
+            case BLOG_URL_IDENTIFIER -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_URL_REQUIRED);
 
@@ -46,11 +46,11 @@ public final class BlogValidator {
                 validateRegex(str, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
                 validateLength(str, 3, 15, BLOG_URL_INVALID_LENGTH);
             }
-            case USERNAME -> {
+            case BLOG_USERNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_USERNAME_REQUIRED);
             }
-            case NICKNAME -> {
+            case BLOG_NICKNAME -> {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NICKNAME_REQUIRED);
             }
@@ -64,12 +64,12 @@ public final class BlogValidator {
     }
 
     public enum BlogValidationTarget {
-        ID,
-        USER_ID,
-        PROFILE_ID,
-        NAME,
-        URL_IDENTIFIER,
-        USERNAME,
-        NICKNAME
+        BLOG_ID,
+        BLOG_USER_ID,
+        BLOG_PROFILE_ID,
+        BLOG_NAME,
+        BLOG_URL_IDENTIFIER,
+        BLOG_USERNAME,
+        BLOG_NICKNAME
     }
 }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/validation/BlogValidator.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/validation/BlogValidator.java
@@ -1,6 +1,7 @@
 package nettee.blolet.blog.application.validation;
 
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_ID_REQUIRED;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_INPUT_TYPE_MISMATCHED;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_INVALID_LENGTH;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_REQUIRED;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NICKNAME_REQUIRED;
@@ -58,9 +59,13 @@ public final class BlogValidator {
     }
 
     private static String castToString(Object value) {
-        assert value == null || value instanceof String :
-                "value must be a string or null but is " + value.getClass();
-        return (String) value;
+        if (value == null) return null;
+
+        if (!(value instanceof String str)) {
+            throw BLOG_INPUT_TYPE_MISMATCHED.exception();
+        }
+
+        return str;
     }
 
     public enum BlogValidationTarget {

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/validation/BlogValidator.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/validation/BlogValidator.java
@@ -35,7 +35,6 @@ public final class BlogValidator {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_NAME_REQUIRED);
 
-                // 앞뒤 공백 문자를 제거 후 유효성 확인
                 str = str.strip();
                 validateLength(str, 3, 30, BLOG_NAME_INVALID_LENGTH);
             }
@@ -43,7 +42,6 @@ public final class BlogValidator {
                 String str = castToString(value);
                 validateNotBlank(str, BLOG_URL_REQUIRED);
 
-                // 앞뒤 공백 문자를 제거 후 유효성 확인
                 str = str.strip();
                 validateRegex(str, "^[A-Za-z0-9_-]+$", BLOG_URL_INVALID_FORMAT);
                 validateLength(str, 3, 15, BLOG_URL_INVALID_LENGTH);

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
@@ -3,9 +3,10 @@ package nettee.blolet.blog.web.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import nettee.blolet.blog.application.usecase.subscription.data.SubscriptionStats;
-import nettee.blolet.blog.application.validation.BlogValidator.BlogValidationTarget;
 import nettee.blolet.blog.readmodel.BlogReadModels.BlogDetail;
 
+import static nettee.blolet.blog.application.validation.BlogValidator.BlogValidationTarget.BLOG_NAME;
+import static nettee.blolet.blog.application.validation.BlogValidator.BlogValidationTarget.BLOG_URL_IDENTIFIER;
 import static nettee.blolet.blog.application.validation.BlogValidator.validate;
 
 public final class BlogCommandDto {
@@ -18,8 +19,8 @@ public final class BlogCommandDto {
             String urlIdentifier
     ) {
         public BlogUpdateCommand {
-            validate(BlogValidationTarget.BLOG_NAME, name);
-            validate(BlogValidationTarget.BLOG_URL_IDENTIFIER, urlIdentifier);
+            validate(BLOG_NAME, name);
+            validate(BLOG_URL_IDENTIFIER, urlIdentifier);
         }
     }
 

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/BlogCommandDto.java
@@ -18,8 +18,8 @@ public final class BlogCommandDto {
             String urlIdentifier
     ) {
         public BlogUpdateCommand {
-            validate(BlogValidationTarget.NAME, name);
-            validate(BlogValidationTarget.URL_IDENTIFIER, urlIdentifier);
+            validate(BlogValidationTarget.BLOG_NAME, name);
+            validate(BlogValidationTarget.BLOG_URL_IDENTIFIER, urlIdentifier);
         }
     }
 


### PR DESCRIPTION
<!--
<br />

<table border="3" align="center">
<tr height="45">
  <td>🏗️</td>
  <td>실수로 다른 브랜치의 작업이 섞여 리베이스 예정입니다.</td>
</tr>
</table>

<br />

<table border="3" align="center">
<tr height="45">
  <td>🏗️</td>
  <td>실수로 다른 브랜치의 작업이 섞여 리베이스 예정입니다.</td>
</tr>
</table>

<br />

<table border="3" align="center">
<tr height="45">
  <td>🏗️</td>
  <td>실수로 다른 브랜치의 작업이 섞여 리베이스 예정입니다.</td>
</tr>
</table>

<br />

-->

## Issues

- Resolves #255 

## Description

- **접두사 추가**: `BLOG_`  
  <sup>e.g.,</sup> `NAME` to `BLOG_NAME`
- 블로그 유효성 타깃 열거상수의 <ins>정적 임포트</ins>를 허용합니다.
- 문자열 validator 메서드 사용을 위한 `Object` to `String` 캐스팅에서, `non-null`, `instanceof` 체크를 `assert`에서 런타임 예외로 대치했습니다.

<br />

## Review Points

- services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/dto/**BlogCommandDto**.java

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

사소한 변화지만, 사소한 작업 영역에 어울리는 개선이라 생각했습니다.  
(관심도가 낮은 유효성 코드 해석에 불필요하게 시선이 뺏기지 않도록 하기 위함.)

<table>
<tr>
  <td>AS-IS</td>
  <td>TO-BE</td>
</tr>
<tr>
  <td>
  
  ```java
  validate(BlogValidationTarget.NAME, name);
  validate(BlogValidationTarget.URL_IDENTIFIER, urlIdentifier);
  ```
  
  </td>
  <td>
  
  ```java
  validate(BLOG_NAME, name);
  validate(BLOG_URL_IDENTIFIER, urlIdentifier);
  ```
  
  </td>
</tr>
</table>
