### PR TITLE
Blog > WebMVC: API 엔드포인트가 이제 인가 필터로부터 정제된 회원 정보를 제공받습니다.

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
@@ -11,9 +11,11 @@ import org.springframework.stereotype.Service;
 import java.util.Objects;
 
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_COMMAND_FORBIDDEN;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_ID_REQUIRED;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_MAXIMUM_EXCEEDED;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_CANNOT_BE_BLANK;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NOT_FOUND;
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
 
 @Service
 @RequiredArgsConstructor
@@ -44,9 +46,16 @@ public class BlogCommandService implements BlogCreateUseCase, BlogUpdateUseCase,
     @Override
     public Blog update(Blog blog) {
         Objects.requireNonNull(blog, "Blog cannot be null");
-        String blogId = Objects.requireNonNull(blog.getId(), "blogId cannot be null");
-        String name = Objects.requireNonNull(blog.getName(), "blog name cannot be null");
-        String url = Objects.requireNonNull(blog.getUrlIdentifier(), "blog url identifier cannot be null");
+        String blogId = Objects.requireNonNull(blog.getId(), () -> {
+            throw BLOG_ID_REQUIRED.exception();
+        });
+        String userId = Objects.requireNonNull(blog.getUserId(), () -> {
+            throw BLOG_OWNER_ID_REQUIRED.exception();
+        });
+        String name = Objects.requireNonNull(blog.getName(), () -> {
+            throw BLOG_NAME_CANNOT_BE_BLANK.exception();
+        });
+        String url = blog.getUrlIdentifier();
 
         if (name.isBlank()) {
             throw BLOG_NAME_CANNOT_BE_BLANK.exception();

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_COMMAND_FORBIDDEN;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_MAXIMUM_EXCEEDED;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_CANNOT_BE_BLANK;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NOT_FOUND;
@@ -54,6 +55,11 @@ public class BlogCommandService implements BlogCreateUseCase, BlogUpdateUseCase,
         // Exception when BLOG_NOT_FOUND
         var entity = commandRepository.findById(blogId)
                 .orElseThrow(BLOG_NOT_FOUND::exception);
+
+        // validate ownership
+        if (!Objects.equals(userId, entity.getUserId())) {
+            throw BLOG_COMMAND_FORBIDDEN.exception();
+        }
 
         // update
         entity.prepareUpdate()

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogCommandService.java
@@ -80,11 +80,16 @@ public class BlogCommandService implements BlogCreateUseCase, BlogUpdateUseCase,
     }
 
     @Override
-    public Blog updateUrl(String blogId, String url) {
+    public Blog updateUrl(String userId, String blogId, String url) {
         Objects.requireNonNull(blogId, "blogId cannot be null");
         Objects.requireNonNull(url, "url cannot be null");
         var entity = commandRepository.findById(blogId)
                 .orElseThrow(BLOG_NOT_FOUND::exception);
+
+        // validate ownership
+        if (!Objects.equals(userId, entity.getUserId())) {
+            throw BLOG_COMMAND_FORBIDDEN.exception();
+        }
 
         entity.updateUrl(url);
 

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogUpdateUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogUpdateUseCase.java
@@ -4,5 +4,5 @@ import nettee.blolet.blog.domain.Blog;
 
 public interface BlogUpdateUseCase {
     Blog update(Blog blog);
-    Blog updateUrl(String blogId, String url);
+    Blog updateUrl(String userId, String blogId, String url);
 }

--- a/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogCommandServiceTest.kt
+++ b/services/blog/application/src/test/kotlin/nettee/blolet/blog/application/service/BlogCommandServiceTest.kt
@@ -101,6 +101,7 @@ class BlogCommandServiceTest : FreeSpec({
 
     "[UPDATE] 블로그 수정 시" - {
         val targetId = "1"
+        val userId = "USER-1"
         val newName = "new blog name"
         val newUrl = "https://user1.blolet.com"
 
@@ -121,7 +122,7 @@ class BlogCommandServiceTest : FreeSpec({
             // 조회 시 원본 반환
             every { commandPort.findById(targetId) } returns Optional.of(original)
             // 저장 시 capture 후, updatedAt만 갱신된 새 객체 반환
-            every { commandPort.save(capture(captured)) } answers {
+            every { commandPort.update(capture(captured)) } answers {
                 val input: Blog = firstArg()
                 Blog.builder()
                     .id(input.id!!)
@@ -138,6 +139,7 @@ class BlogCommandServiceTest : FreeSpec({
             // action
             val updatingBlog = Blog.builder()
                 .id(targetId)
+                .userId(userId)
                 .name(newName)
                 .urlIdentifier(newUrl)
                 .build()
@@ -150,9 +152,9 @@ class BlogCommandServiceTest : FreeSpec({
             updated.urlIdentifier shouldBe newUrl
 
             // 호출 순서 확인
-            verifySequence {
+            verifyOrder {
                 commandPort.findById(targetId)
-                commandPort.save(any())
+                commandPort.update(any())
             }
         }
 
@@ -160,6 +162,7 @@ class BlogCommandServiceTest : FreeSpec({
             // action & assert
             val updatingBlog = Blog.builder()
                 .id(targetId)
+                .userId(userId)
                 .name(null)
                 .urlIdentifier(newUrl)
                 .build()
@@ -176,6 +179,7 @@ class BlogCommandServiceTest : FreeSpec({
             // action
             val updatingBlog = Blog.builder()
                 .id(targetId)
+                .userId(userId)
                 .name(newName)
                 .urlIdentifier(null)
                 .build()
@@ -185,9 +189,9 @@ class BlogCommandServiceTest : FreeSpec({
             updated.name shouldBe newName
             updated.urlIdentifier shouldBe original.urlIdentifier // URL 변경 없음
 
-            verifySequence {
+            verifyOrder {
                 commandPort.findById(targetId)
-                commandPort.save(any())
+                commandPort.update(any())
             }
         }
     }
@@ -198,9 +202,10 @@ class BlogCommandServiceTest : FreeSpec({
         val oldUrl = "https://old.url"
         val newUrl = "https://new.url"
         val now = Instant.now()
+        val userId = "USER-1"
         val originalBlog = Blog.builder()
             .id(targetId)
-            .userId("USER-1")
+            .userId(userId)
             .name("A Blog")
             .urlIdentifier(oldUrl)
             .createdAt(now)
@@ -232,7 +237,7 @@ class BlogCommandServiceTest : FreeSpec({
         "✅ 존재하는 블로그의 URL이 정상적으로 업데이트되어 저장된다" {
 
             // action
-            val updated = commandService.updateUrl(targetId, newUrl)
+            val updated = commandService.updateUrl(userId, targetId, newUrl)
 
             // assert: URL이 바뀌었는지, 반환 객체가 save 호출된 엔티티와 동일한지
             updated.urlIdentifier shouldBeEqual newUrl
@@ -246,7 +251,7 @@ class BlogCommandServiceTest : FreeSpec({
 
         "🚧 blogId가 null이면 NPE를 던진다" {
             shouldThrow<NullPointerException> {
-                commandService.updateUrl(null, "https://any.url")
+                commandService.updateUrl(userId, null, "https://any.url")
             }
 
             verify(inverse = true) { commandPort.save(any()) }
@@ -255,7 +260,7 @@ class BlogCommandServiceTest : FreeSpec({
         "🚧 존재하지 않는 블로그 ID로 조회 시 BLOG_NOT_FOUND 예외를 던진다" {
 
             val ex = shouldThrow<CustomException> {
-                commandService.updateUrl(wrongId, "https://any.url")
+                commandService.updateUrl(userId, wrongId, "https://any.url")
             }
             ex.errorCode shouldBeEqual BLOG_NOT_FOUND
 
@@ -267,7 +272,7 @@ class BlogCommandServiceTest : FreeSpec({
             every { commandPort.findById(targetId) } returns Optional.of(originalBlog)
 
             shouldThrow<NullPointerException> {
-                commandService.updateUrl(targetId, null)
+                commandService.updateUrl(userId, targetId, null)
             }
 
             verify(inverse = true) { commandPort.save(any()) }

--- a/services/blog/driving/web-mvc/build.gradle.kts
+++ b/services/blog/driving/web-mvc/build.gradle.kts
@@ -5,6 +5,8 @@ dependencies {
     api(project(blogApi))
     api(project(blogApplication))
 
+    compileOnly(project(":security-blolet-jwt-filter"))
+
     // validation
     compileOnly("jakarta.validation:jakarta.validation-api")
     compileOnly("jakarta.annotation:jakarta.annotation-api")

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/BlogCommandApi.java
@@ -12,6 +12,8 @@ import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUnsubscribeResponse;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateCommand;
 import nettee.blolet.blog.web.dto.BlogCommandDto.BlogUpdateResponse;
 import nettee.blolet.blog.web.mapper.BlogDtoMapper;
+import nettee.jwt.annotation.AuthUser;
+import nettee.jwt.annotation.AuthorizedUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,8 +41,12 @@ public class BlogCommandApi {
             summary = "블로그 정보 수정",
             description = "사용자가 소유한 블로그 정보를 수정합니다."
     )
-    public BlogUpdateResponse updateBlog(@PathVariable("blogId") String blogId, @RequestBody BlogUpdateCommand dto) {
-        var domain = mapper.toDomain(blogId, dto);
+    public BlogUpdateResponse updateBlog(
+            @PathVariable("blogId") String blogId,
+            @RequestBody BlogUpdateCommand dto,
+            @AuthUser AuthorizedUser user
+    ) {
+        var domain = mapper.toDomain(user.userId(), blogId, dto);
         return mapper.toUpdateResponse(updateUseCase.update(domain));
     }
 

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/BlogAdminCommandApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/BlogAdminCommandApi.java
@@ -6,6 +6,8 @@ import nettee.blolet.blog.application.usecase.BlogCreateUseCase;
 import nettee.blolet.blog.web.admin.dto.BlogAdminCommandDto.BlogCreateCommand;
 import nettee.blolet.blog.web.admin.dto.BlogAdminCommandDto.BlogCreateResponse;
 import nettee.blolet.blog.web.admin.mapper.BlogAdminDtoMapper;
+import nettee.jwt.annotation.AuthUser;
+import nettee.jwt.annotation.AuthorizedUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,8 +25,11 @@ public class BlogAdminCommandApi {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BlogCreateResponse create(@RequestBody @Valid BlogCreateCommand requestBody) {
-        var blog = mapper.toDomain(requestBody);
+    public BlogCreateResponse create(
+            @RequestBody @Valid BlogCreateCommand requestBody,
+            @AuthUser AuthorizedUser user
+    ) {
+        var blog = mapper.toDomain(user.userId(), requestBody);
         return mapper.toResponse(
                 createUseCase.save(blog)
         );

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/dto/BlogAdminCommandDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/dto/BlogAdminCommandDto.java
@@ -5,7 +5,6 @@ import nettee.blolet.blog.readmodel.BlogReadModels.BlogDetail;
 
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_INVALID_LENGTH;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NAME_REQUIRED;
-import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_OWNER_ID_REQUIRED;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_FORMAT;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_INVALID_LENGTH;
 import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_URL_REQUIRED;
@@ -18,12 +17,10 @@ public final class BlogAdminCommandDto {
 
     @Builder
     public record BlogCreateCommand(
-            String userId,
             String name,
             String url
     ) {
         public BlogCreateCommand {
-            validateNotBlank(userId, BLOG_OWNER_ID_REQUIRED);
             validateNotBlank(name, BLOG_NAME_REQUIRED);
             validateNotBlank(url, BLOG_URL_REQUIRED);
 

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/mapper/BlogAdminDtoMapper.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/mapper/BlogAdminDtoMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface BlogAdminDtoMapper {
-    Blog toDomain(BlogCreateCommand dto);
+    Blog toDomain(String userId, BlogCreateCommand dto);
 
     BlogCreateResponse toResponse(Blog blog);
 }

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/mapper/BlogDtoMapper.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/mapper/BlogDtoMapper.java
@@ -10,7 +10,7 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface BlogDtoMapper {
     @Mapping(target = "id", source = "blogId")
-    Blog toDomain(String blogId, BlogUpdateCommand dto);
+    Blog toDomain(String userId, String blogId, BlogUpdateCommand dto);
     BlogUpdateResponse toUpdateResponse(Blog blog);
     BlogDetail toDetail(Blog blog);
 }


### PR DESCRIPTION
## Issues

- Resolves #244  

## Description

- Blog API 엔드포인트가 이제 인가 필터로부터 정제된 회원 정보를 제공받습니다.
- 기존에 `assert` 동작이나 `Objects.requireNonNull`에 의존하던 `null` 체크 중 일부를 커스텀 에러 코드로 대치했습니다.

<br />

## Review Points

_No response_

<br />

## How Has This Been Tested?

- 기존 테스트 코드만 동작하도록 수정했습니다.
- Ownership 인가 관련 테스트 코드는 추가하지 않았습니다.

<br />

## Additional Notes

_No response_
