### PR TITLE
Draft > Application: 서비스 로직에서 사용자의 블로그 소유권 확인 후 커맨드 작업을 수행합니다.

### DIFF
--- a/services/draft/application/build.gradle.kts
+++ b/services/draft/application/build.gradle.kts
@@ -2,10 +2,16 @@ val draftDomain: String by project
 val draftException: String by project
 val draftReadModel: String by project
 
+val blogClientWebMvc: String by project
+
 dependencies {
     api(project(draftDomain))
     api(project(draftException))
     api(project(draftReadModel))
+
+    // internal clients
+    api(project(blogClientWebMvc))
+
     // spring
     implementation("org.springframework.data:spring-data-commons")
     implementation("org.springframework:spring-tx")

--- a/services/draft/application/src/main/java/nettee/draft/application/service/DraftCommandService.java
+++ b/services/draft/application/src/main/java/nettee/draft/application/service/DraftCommandService.java
@@ -11,6 +11,7 @@ import nettee.draft.application.usecase.DraftUpdateUseCase;
 import org.springframework.stereotype.Service;
 
 import static nettee.draft.exception.DraftErrorCode.DRAFT_FORBIDDEN;
+import static nettee.draft.exception.DraftErrorCode.DRAFT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +33,11 @@ public class DraftCommandService implements DraftCreateUseCase, DraftUpdateUseCa
 
     @Override
     public void deleteDraft(String userId, String draftId) {
-        // TODO check if this user owns the blog
+        var blogId = draftCommandPort.findById(draftId)
+                .orElseThrow(DRAFT_NOT_FOUND::exception)
+                .blogId();
+        validateOwnership(userId, blogId);
+
         draftCommandPort.updateStatus(draftId, DraftStatus.REMOVED);
     }
 

--- a/services/draft/application/src/main/java/nettee/draft/application/service/DraftCommandService.java
+++ b/services/draft/application/src/main/java/nettee/draft/application/service/DraftCommandService.java
@@ -1,6 +1,7 @@
 package nettee.draft.application.service;
 
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.export.client.api.BlogClient;
 import nettee.draft.application.port.DraftCommandPort;
 import nettee.draft.domain.Draft;
 import nettee.draft.domain.type.DraftStatus;
@@ -9,20 +10,23 @@ import nettee.draft.application.usecase.DraftDeleteUseCase;
 import nettee.draft.application.usecase.DraftUpdateUseCase;
 import org.springframework.stereotype.Service;
 
+import static nettee.draft.exception.DraftErrorCode.DRAFT_FORBIDDEN;
+
 @Service
 @RequiredArgsConstructor
 public class DraftCommandService implements DraftCreateUseCase, DraftUpdateUseCase, DraftDeleteUseCase {
     private final DraftCommandPort draftCommandPort;
+    private final BlogClient blogClient;
 
     @Override
     public Draft createDraft(String userId, Draft draft) {
-        // TODO check if this user owns the blog
+        validateOwnership(userId, draft.getBlogId());
         return draftCommandPort.save(draft);
     }
 
     @Override
     public Draft updateDraft(String userId, Draft draft) {
-        // TODO check if this user owns the blog
+        validateOwnership(userId, draft.getBlogId());
         return draftCommandPort.update(draft);
     }
 
@@ -30,5 +34,14 @@ public class DraftCommandService implements DraftCreateUseCase, DraftUpdateUseCa
     public void deleteDraft(String userId, String draftId) {
         // TODO check if this user owns the blog
         draftCommandPort.updateStatus(draftId, DraftStatus.REMOVED);
+    }
+
+    private void validateOwnership(String userId, String draftId) {
+        var isOwner = blogClient.verifyOwnership(userId, draftId)
+                .isOwner();
+
+        if (!isOwner) {
+            throw DRAFT_FORBIDDEN.exception();
+        }
     }
 }


### PR DESCRIPTION
<!--

<br /><br /><br /><br /><br />

<table align="center" border="30">
<tr>
  <td>🏗️ 선행 작업 병합 후, 리베이스할 예정입니다.</td>
</tr>
</table>

<br /><br /><br /><br /><br />
그니까 아직 리뷰하지 말라니깐용.
<br /><br /><br /><br /><br />
<br /><br /><br /><br /><br />

-->

## Issues

- Resolves #269 

## Description

- 간단한 작업 프로세스를 따랐습니다.
  1. `draft-application` 모듈에 `blog-client-webmvc` 모듈을 추가합니다.
  2. 서비스 클래스에서 `BlogClient blogClient` 타입 및 이름으로 빈을 주입받습니다.
  3. 소유권 확인 메서드를 호출하여 소유권을 확인했습니다. (*이 메서드는 결과를 캐싱합니다.)  
      ```java
      var isOwner = blogClient.verifyOwnership(userId, draftId).isOwner();
      ```
- Rel: #270 > #269 

<br />

## Review Points

- 앞서 설명한 작업 프로세스를 참고하여, 서비스 클래스의 로직 위주로 살펴봐 주시면 감사하겠습니다.

<br />

## How Has This Been Tested?

- Postman으로 실행하여 육안으로 일부 확인했습니다.  
  - Draft 서비스 및 어댑터 수정 사항을 추가로 발견했습니다. (업데이트 시 누락된 일부 필드 삭제되는 현상 등)

<br />

## Additional Notes

_No response_
