### PR TITLE
Auth: 로그인 시 status 컬럼을 자바 객체 필드로 매핑할 때 오류가 발생합니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS "auth"."user" (
     "nickname"	        VARCHAR(255)   ,
     "email"	            VARCHAR(255)   ,
     -- 공통 컬럼
-    "status"	        VARCHAR	        DEFAULT 'ACTIVE'    ,
+    "status"	        INT	            DEFAULT 20    ,
     "created_at"	    TIMESTAMP		DEFAULT NOW()       NOT NULL,
     "updated_at"	    TIMESTAMP		DEFAULT NOW()       NOT NULL
 );
@@ -27,7 +27,7 @@ COMMENT ON COLUMN "auth"."user"."locked_until"        IS '계정 잠금 해제 �
 COMMENT ON COLUMN "auth"."user"."nickname"            IS '사용자닉네임';
 COMMENT ON COLUMN "auth"."user"."email"               IS '사용자의 이메일 주소';
 COMMENT ON COLUMN "auth"."user"."status"              IS
-        '사용자 계정 상태: PENDING(가입 대기), ACTIVE(활동), SUSPENDED(정지), PROTECTED(보호), REMOVED(탈퇴)';
+        '사용자 계정 상태 코드: PENDING(10, 가입 대기), ACTIVE(20, 활동), SUSPENDED(30, 정지), PROTECTED(40, 보호), REMOVED(0, 탈퇴)';
 COMMENT ON COLUMN "auth"."user"."created_at"          IS '생성일자';
 COMMENT ON COLUMN "auth"."user"."updated_at"          IS '수정일자';
 

--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS "auth"."user" (
     "nickname"	        VARCHAR(255)   ,
     "email"	            VARCHAR(255)   ,
     -- 공통 컬럼
-    "status"	        INT	            DEFAULT 20    ,
+    "status"	        INT	            DEFAULT 20          NOT NULL,
     "created_at"	    TIMESTAMP		DEFAULT NOW()       NOT NULL,
     "updated_at"	    TIMESTAMP		DEFAULT NOW()       NOT NULL
 );


### PR DESCRIPTION
## Issues

- Resolves #276 

## Description

- DB → Entity 매핑 시, status 컬럼 매핑에 실패하여 발생한 에러입니다.
- 현재 **DB 저장 공간 효율과 유연함을 위해** 사용자 status 를 DB에 저장했을 시, 특정 code 값으로 매핑하여 저장하고 있습니다. (with. `UserEntityStatusConverter`)
- 따라서 현재 flyway 스크립트에서 status 컬럼의 Default 값을 기존 "Active"에서 코드 값 20(int)으로 관리하도록 수정합니다.

<br />

## Review Points

- 자유로운 리뷰 부탁드립니다!

<br />

## How Has This Been Tested?

- 디버깅 모드로 DB → Entity 매핑이 정상적으로 동작함을 확인하였습니다.
