### PR TITLE
Core > Security: 인가 필터에서 요청경로 비교에 패턴 매칭을 사용합니다.

### DIFF
--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -41,7 +41,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
      */
     @PostConstruct
     public void init() {
-        this.excludePathPatterns = filterConfig.getExcludePaths().stream()
+        var excludedPaths = filterConfig.getExcludePaths();
+        assert excludedPaths != null : "Excluded paths cannot be null.";
+
+        this.excludePathPatterns = excludedPaths.stream()
                 .map(patternParser::parse)
                 .toList();
     }

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/jwt/filter/JwtAuthorizationFilter.java
@@ -2,6 +2,7 @@ package nettee.jwt.filter;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,9 +13,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nettee.jwt.parser.JwtParser;
+import org.springframework.http.server.PathContainer;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 /**
  * JWT 인가 필터
@@ -27,7 +31,24 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtParser jwtParser;
     private final JwtFilterConfig filterConfig;
+    private final PathPatternParser patternParser;
 
+    private List<PathPattern> excludePathPatterns;
+
+    /**
+     * 필터 초기화 메서드
+     * filter 제외 경로 패턴들을 미리 파싱하여 저장
+     */
+    @PostConstruct
+    public void init() {
+        this.excludePathPatterns = filterConfig.getExcludePaths().stream()
+                .map(patternParser::parse)
+                .toList();
+    }
+
+    /**
+     * HTTP 요청을 필터링합니다.
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                   HttpServletResponse response,
@@ -72,8 +93,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
+        PathContainer pathContainer = PathContainer.parsePath(requestURI);
 
-        return filterConfig.getExcludePaths().contains(requestURI);
+        // pattern 매칭을 통해 필터링 제외 경로인지 확인
+        return excludePathPatterns.stream()
+                .anyMatch(pattern -> pattern.matches(pathContainer));
     }
 
     /**


### PR DESCRIPTION
## Issues

- Resolves #273 

## Description

- blolet-jwt-filter에서는 클라이언트 요청 시 JWT 토큰을 필요로 합니다.
- 단, 일부 경로는 JWT 토큰이 필요하지 않으며, 기존에는 요청 경로와 API 엔드포인트가 완전히 일치하는지 확인했습니다. 
- 이를 보다 유연하게 처리하기 위해, 경로 패턴과의 일치 여부를 확인하는 `pattern.matches` 방식으로 수정하였습니다.


<br />

## Review Points

- 자유로운 리뷰 부탁드립니다.

<br />

## How Has This Been Tested?

- `blolet.jwt.filter.yml`에서 패턴 매칭으로 수정한 뒤, 포스트맨으로 api가 정상적으로 응답하는 것을 확인했습니다.

```java
blolet:
  jwt:
    filter:
      exclude-paths:
        - /auth/**
```
