### PR TITLE
Monolith: Swagger UI 접속 경로는 인가 필터를 bypass하도록 수정합니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
+++ b/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
@@ -3,6 +3,9 @@ blolet:
     filter:
       exclude-paths:
         - /actuator/health
+        # Docs 등 static
+        - /swagger-ui/**
+        - /v3/api-docs/**
         - /auth/signup
         - /auth/login
         - /auth/email/verification/send


### PR DESCRIPTION
## Issues

- Resolves #303 

<br />

## Description

- 다음 경로는 인가 필터를 우회합니다.
  - `/swagger-ui/**` 및 `/v3/api-docs/**`

<br />

## Review Points

- 간단한 설정 작업이므로 리뷰를 우회하여 병합합니다.
- 이후 발견되는 피드백을 받겠습니다.

<br />

## How Has This Been Tested?

- 정상적으로 접속되는 것을 육안으로 확인했습니다.  
  http://localhost:8080/swagger-ui/index.html

<br />

## Additional Notes

- 이 이슈는 @choi1five 님께서 발견해서 피드백해 주셨습니다.
