### PR TITLE
Common > Validation: 유효성 응답 모델에 "string" 타입 프로퍼티 모델 추가

### DIFF
--- a/common/src/main/java/nettee/common/validation/model/StringValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/StringValidationProperty.java
@@ -53,16 +53,16 @@ public record StringValidationProperty(
             messages.put(REQUIRED, "필수 입력 항목입니다.");
         }
 
-        if (regexp != null && !regexp.isBlank() && messages.containsKey(REGEXP)) {
+        if (regexp != null && !regexp.isBlank() && !messages.containsKey(REGEXP)) {
             log.warn("정규표현식의 안내 메시지가 필요합니다.");
             messages.put(REGEXP, "올바른 입력 양식이 아닙니다.");
         }
 
-        if (minLength != null && messages.containsKey(MIN_LENGTH)) {
+        if (minLength != null && !messages.containsKey(MIN_LENGTH)) {
             messages.put(MIN_LENGTH, minLength + "글자 이상을 입력해야 합니다.");
         }
 
-        if (maxLength != null && messages.containsKey(MAX_LENGTH)) {
+        if (maxLength != null && !messages.containsKey(MAX_LENGTH)) {
             messages.put(MAX_LENGTH, "최대 " + maxLength + "글자까지 입력할 수 있습니다.");
         }
 

--- a/common/src/main/java/nettee/common/validation/model/StringValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/StringValidationProperty.java
@@ -1,0 +1,72 @@
+package nettee.common.validation.model;
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import nettee.common.validation.model.interfaces.LengthValidationProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MAX_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MIN_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REGEXP;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
+
+@Builder
+@Slf4j
+public record StringValidationProperty(
+        String type,
+        Boolean required,
+        String regexp,
+        Integer minLength,
+        Integer maxLength,
+        Map<String, String> messages
+) implements LengthValidationProperty {
+    public StringValidationProperty {
+        assert type == null || type.isBlank() || "string".equals(type)
+                : "type must be 'string'. If new spec types are added, update this assertion accordingly.\n" +
+                "type 속성은 반드시 'string'이어야 합니다. 만약 새로운 값을 추가한다면 이 assert 구문을 함께 고쳐야 합니다.";
+
+        if (type == null || type.isBlank()) {
+            log.warn("StringValidationProperty had a blank 'type' property. Setting 'type' to 'string'.");
+            type = "string";
+        }
+
+        if (required == null) {
+            required = false;
+        }
+
+        // empty (or blank) to null
+        if (regexp != null && regexp.isBlank()) {
+            regexp = null;
+        }
+
+        // 둘 다 존재한다면 min < max (where, 둘 다 음수가 아님.)
+        assert minLength == null || maxLength == null || (minLength >= 0 && maxLength >= 0 && minLength <= maxLength)
+                : "Invalid length bounds: minLength must be >= 0, maxLength must be >= 0, and minLength <= maxLength.";
+
+        if (messages == null && (required || regexp != null || minLength != null || maxLength != null)) {
+            messages = new HashMap<>();
+        }
+
+        if (required && !messages.containsKey(REQUIRED)) {
+            messages.put(REQUIRED, "필수 입력 항목입니다.");
+        }
+
+        if (regexp != null && !regexp.isBlank() && messages.containsKey(REGEXP)) {
+            log.warn("정규표현식의 안내 메시지가 필요합니다.");
+            messages.put(REGEXP, "올바른 입력 양식이 아닙니다.");
+        }
+
+        if (minLength != null && messages.containsKey(MIN_LENGTH)) {
+            messages.put(MIN_LENGTH, minLength + "글자 이상을 입력해야 합니다.");
+        }
+
+        if (maxLength != null && messages.containsKey(MAX_LENGTH)) {
+            messages.put(MAX_LENGTH, "최대 " + maxLength + "글자까지 입력할 수 있습니다.");
+        }
+
+        assert messages != null;
+        messages = Map.copyOf(messages);
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/ValidationResponseModel.java
+++ b/common/src/main/java/nettee/common/validation/model/ValidationResponseModel.java
@@ -1,0 +1,18 @@
+package nettee.common.validation.model;
+
+import nettee.common.validation.model.interfaces.BaseValidationProperty;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ValidationResponseModel(
+        Map<String, BaseValidationProperty> validations,
+        Instant serverTime,
+        Instant lastUpdatedAt
+) {
+    public ValidationResponseModel {
+        if (serverTime == null) {
+            serverTime = Instant.now();
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
@@ -6,4 +6,31 @@ public interface BaseValidationProperty {
     String type();
     Boolean required();
     Map<String, String> messages();
+
+    final class ReservedFieldNames {
+        // base
+        public static final String TYPE = "type";
+        public static final String REQUIRED = "required";
+        public static final String MESSAGES = "messages";
+
+        // length
+        public static final String MIN_LENGTH = "minLength";
+        public static final String MAX_LENGTH = "maxLength";
+
+        // value bound
+        public static final String MIN = "min";
+        public static final String MAX = "max";
+        public static final String INCLUSIVE = "inclusive";
+
+        private ReservedFieldNames() {}
+    }
+
+    final class ExpectedTypes {
+        public static final String STRING = "string";
+        public static final String NUMBER_INT = "number:int";
+        public static final String NUMBER_DECIMAL = "number:decimal";
+        public static final String ARRAY = "array";
+        public static final String DATETIME_ABSOLUTE = "datetime:absolute";
+        public static final String DATETIME_RELATIVE = "datetime:relative";
+    }
 }

--- a/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
@@ -1,0 +1,9 @@
+package nettee.common.validation.model.interfaces;
+
+import java.util.Map;
+
+public interface BaseValidationProperty {
+    String type();
+    Boolean required();
+    Map<String, String> messages();
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
@@ -22,6 +22,14 @@ public interface BaseValidationProperty {
         public static final String MAX = "max";
         public static final String INCLUSIVE = "inclusive";
 
+        // duration
+        public static final String MIN_DURATION = "minDuration";
+        public static final String MAX_DURATION = "maxDuration";
+
+        // step
+        public static final String STEP = "step";
+        public static final String STEP_EPOCH = "stepEpoch";
+        
         private ReservedFieldNames() {}
     }
 

--- a/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
@@ -29,6 +29,9 @@ public interface BaseValidationProperty {
         // step
         public static final String STEP = "step";
         public static final String STEP_EPOCH = "stepEpoch";
+
+        // regexp
+        public static final String REGEXP = "regexp";
         
         private ReservedFieldNames() {}
     }

--- a/common/src/main/java/nettee/common/validation/model/interfaces/LengthValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/LengthValidationProperty.java
@@ -1,0 +1,6 @@
+package nettee.common.validation.model.interfaces;
+
+public interface LengthValidationProperty extends BaseValidationProperty {
+    Integer minLength();
+    Integer maxLength();
+}


### PR DESCRIPTION
<!--
<br /><br /><br /><br /><br />

<table align="center" border="30">
<tr>
  <td>🏗️ 선행 작업 병합 후, 리베이스할 예정입니다.</td>
</tr>
</table>

<br /><br /><br /><br /><br />
그니까 아직 리뷰하지 말라니깐용.
<br /><br /><br /><br /><br />
<br /><br /><br /><br /><br />
-->

> 이 PR을 리뷰할 경우 #326 PR을 리뷰하지 않아도 됩니다.

## Issues

- Resolves #327 

<br />

## Description

- 문자열 데이터의 유효성 모델을 추가합니다.
- Rel: #323 

<br />

## Review Points

- 노션 스펙을 참고하실 수 있습니다. (로그인 필요)  
  https://www.notion.so/nettee/Auth-User-API-25001973b23a800c9e9fe2392aa7fa97#25001973b23a802aad45ea139d9f1743
- 관련 파일을 참고하실 수 있습니다.  
  - common/src/main/java/nettee/common/validation/model/interfaces/**BaseValidationProperty**.java  
    ```java
    public interface BaseValidationProperty {
        String type();
        Boolean required();
        Map<String, String> messages();
        
        // ... (중략)
    }
    ```  
    ```java
    public interface LengthValidationProperty extends BaseValidationProperty {
        Integer minLength();
        Integer maxLength();
    }
    ```
  - common/src/main/java/nettee/common/validation/model/**ValidationResponseModel**.java

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

### 다이어그램

```mermaid
classDiagram
    class BaseValidationProperty {
        &lt;&lt;nterface&gt;&gt;
        +String type()
        +Boolean required()
        +Map~String,String~ messages()
    }

    class LengthValidationProperty {
        &lt;&lt;nterface&gt;&gt;
        +Integer minLength()
        +Integer maxLength()
    }
    
    class StringValidationProperty {
        &lt;&lt;record&gt;&gt;
        +String type()
        +Boolean required()
        +Map~String,String~ messages()
        +Integer minLength()
        +Integer maxLength()
    }

    BaseValidationProperty <|-- LengthValidationProperty
    LengthValidationProperty <|.. StringValidationProperty
```