### PR TITLE
Common > Validation: 유효성 응답 모델에 "datetime:{variant}" 타입 프로퍼티 모델들 추가

### DIFF
--- a/common/src/main/java/nettee/common/validation/model/AbsoluteDateTimeValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/AbsoluteDateTimeValidationProperty.java
@@ -54,10 +54,10 @@ public record AbsoluteDateTimeValidationProperty(
         if (required && !messages.containsKey(REQUIRED)) {
             messages.put(REQUIRED, "필수 입력 항목입니다.");
         }
-        if (since != null && messages.containsKey(SINCE)) {
+        if (since != null && !messages.containsKey(SINCE)) {
             messages.put(SINCE, since + " 이후만 선택할 수 있습니다.");
         }
-        if (until != null && messages.containsKey(UNTIL)) {
+        if (until != null && !messages.containsKey(UNTIL)) {
             messages.put(UNTIL, "최대 " + until + "까지 선택할 수 있습니다.");
         }
 

--- a/common/src/main/java/nettee/common/validation/model/AbsoluteDateTimeValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/AbsoluteDateTimeValidationProperty.java
@@ -1,0 +1,68 @@
+package nettee.common.validation.model;
+
+import nettee.common.validation.model.interfaces.SinceUntilDateTimeValidationProperty;
+import nettee.common.validation.model.interfaces.SteppedDateTimeValidationProperty;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.SINCE;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.UNTIL;
+
+public record AbsoluteDateTimeValidationProperty(
+        String type,
+        Boolean required,
+        Instant since,
+        Instant until,
+        List<Boolean> inclusive,
+        String step,
+        String stepEpoch,
+        Map<String, String> messages
+) implements SinceUntilDateTimeValidationProperty, SteppedDateTimeValidationProperty {
+    public AbsoluteDateTimeValidationProperty {
+        assert type == null || type.isBlank() || "datetime:absolute".equals(type)
+                : "type must be 'datetime:absolute'. If new spec types are added, update this assertion accordingly.\n"
+                + "type 속성은 반드시 'datetime:absolute'여야 합니다. 만약 새로운 값을 추가한다면 이 assert 구문을 함께 고쳐야 합니다.";
+        assert since == null || until == null || !since.isAfter(until) : "since must be <= until when both are provided.";
+        assert inclusive == null || inclusive.size() == 2 : "Invalid inclusive size: inclusive.size() == 2";
+        assert stepEpoch == null || stepEpoch.isBlank() || (step != null && !step.isBlank())
+                : "stepEpoch requires step. If stepEpoch is provided, step must also be provided.";
+
+        if (type == null || type.isBlank()) {
+            type = "datetime:absolute";
+        }
+        if (required == null) {
+            required = false;
+        }
+
+        if (step != null && step.isBlank()) {
+            step = null;
+        }
+        if (stepEpoch != null && stepEpoch.isBlank()) {
+            stepEpoch = null;
+        }
+
+        // messages: 안내가 필요한 항목이 있으면 맵 생성
+        if (messages == null && (required || since != null || until != null)) {
+            messages = new HashMap<>();
+        }
+
+        // 기본 안내문 자동 채움(키가 존재할 때만 덮어씀)
+        if (required && !messages.containsKey(REQUIRED)) {
+            messages.put(REQUIRED, "필수 입력 항목입니다.");
+        }
+        if (since != null && messages.containsKey(SINCE)) {
+            messages.put(SINCE, since + " 이후만 선택할 수 있습니다.");
+        }
+        if (until != null && messages.containsKey(UNTIL)) {
+            messages.put(UNTIL, "최대 " + until + "까지 선택할 수 있습니다.");
+        }
+
+        // 불변화
+        assert messages != null;
+        messages = java.util.Map.copyOf(messages);
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/RelativeDateTimeValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/RelativeDateTimeValidationProperty.java
@@ -1,0 +1,76 @@
+package nettee.common.validation.model;
+
+import nettee.common.validation.model.interfaces.DurationBoundedValidationProperty;
+import nettee.common.validation.model.interfaces.DurationValidationSpec;
+import nettee.common.validation.model.interfaces.SteppedDateTimeValidationProperty;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MAX_DURATION;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MIN_DURATION;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
+
+public record RelativeDateTimeValidationProperty(
+        String type,
+        Boolean required,
+        DurationValidationSpec minDuration,
+        DurationValidationSpec maxDuration,
+        List<Boolean> inclusive,
+        String step,
+        String stepEpoch,
+        Map<String, String> messages
+) implements DurationBoundedValidationProperty, SteppedDateTimeValidationProperty {
+    public RelativeDateTimeValidationProperty {
+        assert type == null || type.isBlank() || "datetime:relative".equals(type)
+                : "type must be 'datetime:relative'. If new spec types are added, update this assertion accordingly.\n"
+                + "type 속성은 반드시 'datetime:relative'여야 합니다. 만약 새로운 값을 추가한다면 이 assert 구문을 함께 고쳐야 합니다.";
+        assert minDuration == null || maxDuration == null || minDuration.ref().equals(maxDuration.ref())
+                : "minDuration.ref and maxDuration.ref must match when both are provided. 지금은 동일한 ref만 지원합니다.";
+        assert inclusive == null || inclusive.size() == 2 : "Invalid inclusive size: inclusive.size() == 2";
+
+        // step, stepEpoch 값이 비어 있으면 null로 정리
+        if (step != null && step.isBlank()) {
+            step = null;
+        }
+        if (stepEpoch != null && stepEpoch.isBlank()) {
+            stepEpoch = null;
+        }
+
+        // stepEpoch가 존재한다면 step도 반드시 존재해야 함
+        assert stepEpoch == null || step != null : "If stepEpoch is provided, step must also be provided.";
+
+        // 기본값 설정
+        if (type == null || type.isBlank()) {
+            type = "datetime:relative";
+        }
+        if (required == null) {
+            required = false;
+        }
+        // 스펙상 `inclusive`는 생략 시 `[true, true]`로 취급됩니다. (생략해도 되지만, 명시적으로 전달하기 위해 초기화함.)
+        if (inclusive == null && (minDuration != null || maxDuration != null)) {
+            inclusive = List.of(true, true);
+        }
+
+        // messages: 안내가 필요한 항목이 있으면 맵 생성
+        if (messages == null && (required || minDuration != null || maxDuration != null)) {
+            messages = new HashMap<>();
+        }
+
+        // 기본 안내문 자동 채움(키가 존재할 때만 덮어씀: 다른 파일들과 동일한 패턴)
+        if (required && !messages.containsKey(REQUIRED)) {
+            messages.put(REQUIRED, "필수 입력 항목입니다.");
+        }
+        if (minDuration != null && messages.containsKey(MIN_DURATION)) {
+            messages.put(MIN_DURATION, minDuration.offset() + " 이후만 선택할 수 있습니다.");
+        }
+        if (maxDuration != null && messages.containsKey(MAX_DURATION)) {
+            messages.put(MAX_DURATION, "최대 " + maxDuration.offset() + " 이전까지만 선택할 수 있습니다.");
+        }
+
+        // 불변화
+        assert messages != null;
+        messages = Map.copyOf(messages);
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/RelativeDateTimeValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/RelativeDateTimeValidationProperty.java
@@ -62,10 +62,10 @@ public record RelativeDateTimeValidationProperty(
         if (required && !messages.containsKey(REQUIRED)) {
             messages.put(REQUIRED, "필수 입력 항목입니다.");
         }
-        if (minDuration != null && messages.containsKey(MIN_DURATION)) {
+        if (minDuration != null && !messages.containsKey(MIN_DURATION)) {
             messages.put(MIN_DURATION, minDuration.offset() + " 이후만 선택할 수 있습니다.");
         }
-        if (maxDuration != null && messages.containsKey(MAX_DURATION)) {
+        if (maxDuration != null && !messages.containsKey(MAX_DURATION)) {
             messages.put(MAX_DURATION, "최대 " + maxDuration.offset() + " 이전까지만 선택할 수 있습니다.");
         }
 

--- a/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/BaseValidationProperty.java
@@ -25,6 +25,8 @@ public interface BaseValidationProperty {
         // duration
         public static final String MIN_DURATION = "minDuration";
         public static final String MAX_DURATION = "maxDuration";
+        public static final String SINCE = "since";
+        public static final String UNTIL = "until";
 
         // step
         public static final String STEP = "step";

--- a/common/src/main/java/nettee/common/validation/model/interfaces/DateTimeBaseValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/DateTimeBaseValidationProperty.java
@@ -1,0 +1,4 @@
+package nettee.common.validation.model.interfaces;
+
+public interface DateTimeBaseValidationProperty extends BaseValidationProperty {
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/DurationBoundedValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/DurationBoundedValidationProperty.java
@@ -1,0 +1,9 @@
+package nettee.common.validation.model.interfaces;
+
+import java.util.List;
+
+public interface DurationBoundedValidationProperty extends DateTimeBaseValidationProperty {
+    DurationValidationSpec minDuration();
+    DurationValidationSpec maxDuration();
+    List<Boolean> inclusive();
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/DurationValidationSpec.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/DurationValidationSpec.java
@@ -17,7 +17,8 @@ public record DurationValidationSpec(
                                 .map(Enum::name)
                                 .<String>reduce((acc, cur) -> acc + ", " + cur) +
                         ", or " + RESOURCE_FIELD_REF_PREFIX + "<fieldName> instead." ;
-        assert offset.matches("^P(?!$)(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?$")
+        assert offset.matches("^P(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)W)?(?:(\\d+)D)" +
+                "?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$")
                 : "step must be a valid ISO-8601 duration (e.g. PT5M, P1D, P2W, P3M)";
 
     }

--- a/common/src/main/java/nettee/common/validation/model/interfaces/DurationValidationSpec.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/DurationValidationSpec.java
@@ -1,0 +1,64 @@
+package nettee.common.validation.model.interfaces;
+
+import java.util.Arrays;
+
+import static nettee.common.validation.model.interfaces.DurationValidationSpec.ResourceFieldRef.RESOURCE_FIELD_REF_PREFIX;
+
+public record DurationValidationSpec(
+        String ref,
+        String offset
+) {
+    public DurationValidationSpec {
+        assert ref != null : "Ref must not be null" ;
+        assert offset != null : "Offset cannot be null";
+        assert isSupportedRef(ref) :
+                ref + " is not supported. " + "Use " +
+                        Arrays.stream(ReservedRefTypes.values())
+                                .map(Enum::name)
+                                .<String>reduce((acc, cur) -> acc + ", " + cur) +
+                        ", or " + RESOURCE_FIELD_REF_PREFIX + "<fieldName> instead." ;
+        assert offset.matches("^P(?!$)(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?$")
+                : "step must be a valid ISO-8601 duration (e.g. PT5M, P1D, P2W, P3M)";
+
+    }
+
+    public interface DateTimeValidationRef {
+        String name();
+    }
+
+    private static boolean isSupportedRef(String ref) {
+        for (var refEnumConstant : ReservedRefTypes.values()) {
+            if (refEnumConstant.name().equals(ref)) {
+                return true;
+            }
+        }
+
+        return ref.startsWith(RESOURCE_FIELD_REF_PREFIX);
+    }
+
+    public static class ResourceFieldRef implements DateTimeValidationRef {
+
+        public static final String RESOURCE_FIELD_REF_PREFIX = "RESOURCE_FIELD:";
+        private final String fieldName;
+
+        private ResourceFieldRef(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        public static ResourceFieldRef withFieldName(String fieldName) {
+            return new ResourceFieldRef(fieldName);
+        }
+
+        public String name() {
+            return RESOURCE_FIELD_REF_PREFIX + fieldName;
+        }
+    }
+
+    public enum ReservedRefTypes implements DateTimeValidationRef {
+        NOW,
+        TODAY,
+        RESOURCE_RELATIVE,
+        RESOURCE_TZ_NOW,
+        RESOURCE_TZ_TODAY,
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/SinceUntilDateTimeValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/SinceUntilDateTimeValidationProperty.java
@@ -1,0 +1,10 @@
+package nettee.common.validation.model.interfaces;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface SinceUntilDateTimeValidationProperty extends DateTimeBaseValidationProperty {
+    Instant since();
+    Instant until();
+    List<Boolean> inclusive();
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/SteppedDateTimeValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/SteppedDateTimeValidationProperty.java
@@ -1,0 +1,6 @@
+package nettee.common.validation.model.interfaces;
+
+public interface SteppedDateTimeValidationProperty extends DateTimeBaseValidationProperty {
+    String step();
+    String stepEpoch();
+}


### PR DESCRIPTION
<!--
<br /><br /><br /><br /><br />

<table align="center" border="30">
<tr>
  <td>🏗️ 선행 작업 병합 후, 리베이스할 예정입니다.</td>
</tr>
</table>

<br /><br /><br /><br /><br />
그니까 아직 리뷰하지 말라니깐용.
<br /><br /><br /><br /><br />
<br /><br /><br /><br /><br />
-->

## Issues

- Resolves #332 
- Resolves #333 

<br />

## Description

- Datetime 데이터의 유효성 모델을 추가합니다.
- Rel: #323 

<br />

## Review Points

- 노션 스펙을 참고하실 수 있습니다. (로그인 필요)  
  https://www.notion.so/nettee/Auth-User-API-25001973b23a800c9e9fe2392aa7fa97#25001973b23a802aad45ea139d9f1743
- 관련 파일을 참고하실 수 있습니다.  
  - common/src/main/java/nettee/common/validation/model/interfaces/**BaseValidationProperty**.java  
    ```java
    public interface BaseValidationProperty {
        String type();
        Boolean required();
        Map<String, String> messages();
        
        // ... (중략)
    }
    ```  
  - common/src/main/java/nettee/common/validation/model/**ValidationResponseModel**.java

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

### 다이어그램

```mermaid
classDiagram
direction TB

%% ================= Base & Common =================
class BaseValidationProperty {
  <<interface>>
  +type() String
  +required() Boolean
  +messages() Map~String,String~
}

class DateTimeBaseValidationProperty {
  <<interface>>
}

BaseValidationProperty <|-- DateTimeBaseValidationProperty

%% ================= Interfaces for datetime =================
class SinceUntilDateTimeValidationProperty {
  <<interface>>
  +since() Instant
  +until() Instant
  +inclusive() List~Boolean~
}
DateTimeBaseValidationProperty <|-- SinceUntilDateTimeValidationProperty

class SteppedDateTimeValidationProperty {
  <<interface>>
  +step() String
  +stepEpoch() String
}
DateTimeBaseValidationProperty <|-- SteppedDateTimeValidationProperty

class DurationBoundedValidationProperty {
  <<interface>>
  +minDuration() DurationValidationSpec
  +maxDuration() DurationValidationSpec
  +inclusive() List~Boolean~
}
DateTimeBaseValidationProperty <|-- DurationBoundedValidationProperty

%% ================= Records (implementations) =================
class AbsoluteDateTimeValidationProperty {
  <<record>>
  +type() String
  +required() Boolean
  +since() Instant
  +until() Instant
  +inclusive() List~Boolean~
  +step() String
  +stepEpoch() String
  +messages() Map~String,String~
}
SinceUntilDateTimeValidationProperty <|.. AbsoluteDateTimeValidationProperty
SteppedDateTimeValidationProperty <|.. AbsoluteDateTimeValidationProperty

class RelativeDateTimeValidationProperty {
  <<record>>
  +type() String
  +required() Boolean
  +minDuration() DurationValidationSpec
  +maxDuration() DurationValidationSpec
  +inclusive() List~Boolean~
  +step() String
  +stepEpoch() String
  +messages() Map~String,String~
}
DurationBoundedValidationProperty <|.. RelativeDateTimeValidationProperty
SteppedDateTimeValidationProperty <|.. RelativeDateTimeValidationProperty
DurationValidationSpec <-- RelativeDateTimeValidationProperty : uses

%% ================= Duration spec =================
class DurationValidationSpec {
  <<record>>
  +ref() String
  +offset() String
}
DurationValidationSpec <-- DurationBoundedValidationProperty : returns
```