### PR TITLE
Common > Validation: 유효성 응답 모델에 "array" 타입 프로퍼티 모델 추가

### DIFF
--- a/common/src/main/java/nettee/common/validation/model/ArrayValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/ArrayValidationProperty.java
@@ -21,13 +21,13 @@ public record ArrayValidationProperty(
         Map<String, String> messages
 ) implements LengthValidationProperty {
     public ArrayValidationProperty {
-        assert type == null || type.isBlank() || "string".equals(type)
-                : "type must be 'string'. If new spec types are added, update this assertion accordingly.\n" +
-                "type 속성은 반드시 'string'이어야 합니다. 만약 새로운 값을 추가한다면 이 assert 구문을 함께 고쳐야 합니다.";
+        assert type == null || type.isBlank() || "array".equals(type)
+                : "type must be 'array'. If new spec types are added, update this assertion accordingly.\n" +
+                "type 속성은 반드시 'array'이어야 합니다. 만약 새로운 값을 추가한다면 이 assert 구문을 함께 고쳐야 합니다.";
 
         if (type == null || type.isBlank()) {
-            log.warn("StringValidationProperty had a blank 'type' property. Setting 'type' to 'string'.");
-            type = "string";
+            log.warn("ArrayValidationProperty had a blank 'type' property. Setting 'type' to 'array'.");
+            type = "array";
         }
 
         if (required == null) {

--- a/common/src/main/java/nettee/common/validation/model/ArrayValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/ArrayValidationProperty.java
@@ -1,0 +1,60 @@
+package nettee.common.validation.model;
+
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import nettee.common.validation.model.interfaces.LengthValidationProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MAX_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MIN_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
+
+@Builder
+@Slf4j
+public record ArrayValidationProperty(
+        String type,
+        Boolean required,
+        Integer minLength,
+        Integer maxLength,
+        Map<String, String> messages
+) implements LengthValidationProperty {
+    public ArrayValidationProperty {
+        assert type == null || type.isBlank() || "string".equals(type)
+                : "type must be 'string'. If new spec types are added, update this assertion accordingly.\n" +
+                "type 속성은 반드시 'string'이어야 합니다. 만약 새로운 값을 추가한다면 이 assert 구문을 함께 고쳐야 합니다.";
+
+        if (type == null || type.isBlank()) {
+            log.warn("StringValidationProperty had a blank 'type' property. Setting 'type' to 'string'.");
+            type = "string";
+        }
+
+        if (required == null) {
+            required = false;
+        }
+
+        // 둘 다 존재한다면 min < max (where, 둘 다 음수가 아님.)
+        assert minLength == null || maxLength == null || (minLength >= 0 && maxLength >= 0 && minLength <= maxLength)
+                : "Invalid length bounds: minLength must be >= 0, maxLength must be >= 0, and minLength <= maxLength.";
+
+        if (messages == null && (required || minLength != null || maxLength != null)) {
+            messages = new HashMap<>();
+        }
+
+        if (required && !messages.containsKey(REQUIRED)) {
+            messages.put(REQUIRED, "필수 입력 항목입니다.");
+        }
+
+        if (minLength != null && !messages.containsKey(MIN_LENGTH)) {
+            messages.put(MIN_LENGTH, minLength + "개 원소 이상을 입력해야 합니다.");
+        }
+
+        if (maxLength != null && !messages.containsKey(MAX_LENGTH)) {
+            messages.put(MAX_LENGTH, "최대 " + maxLength + "개 원소까지 입력할 수 있습니다.");
+        }
+
+        assert messages != null;
+        messages = Map.copyOf(messages);
+    }
+}


### PR DESCRIPTION
<!--
<br /><br /><br /><br /><br />

<table align="center" border="30">
<tr>
  <td>🏗️ 선행 작업 병합 후, 리베이스할 예정입니다.</td>
</tr>
</table>

<br /><br /><br /><br /><br />
그니까 아직 리뷰하지 말라니깐용.
<br /><br /><br /><br /><br />
<br /><br /><br /><br /><br />
-->

## Issues

- Resolves #331 

<br />

## Description

- Array(list) 데이터의 유효성 모델을 추가합니다.
- Rel: #323 

<br />

## Review Points

- 노션 스펙을 참고하실 수 있습니다. (로그인 필요)  
  https://www.notion.so/nettee/Auth-User-API-25001973b23a800c9e9fe2392aa7fa97#25001973b23a802aad45ea139d9f1743
- 관련 파일을 참고하실 수 있습니다.  
  - common/src/main/java/nettee/common/validation/model/interfaces/**BaseValidationProperty**.java  
    ```java
    public interface BaseValidationProperty {
        String type();
        Boolean required();
        Map<String, String> messages();
        
        // ... (중략)
    }
    ```  
  - common/src/main/java/nettee/common/validation/model/**ValidationResponseModel**.java

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

### 다이어그램

```mermaid
classDiagram
direction TB

%% ================= Base & Common =================
class BaseValidationProperty {
  <<interface>>
  +type() String
  +required() Boolean
  +messages() Map~String,String~
}

class LengthValidationProperty {
  <<interface>>
  +minLength() Integer
  +maxLength() Integer
}
BaseValidationProperty <-- LengthValidationProperty

class ArrayValidationProperty {
  <<record>>
  +type() String
  +required() Boolean
  +minLength() Integer
  +maxLength() Integer
  +messages() Map~String,String~
}
LengthValidationProperty <.. ArrayValidationProperty : implements
```