### PR TITLE
Draft > API: Draft 부가정보의 유효성 정책을 제공합니다.

### DIFF
--- a/common/src/main/java/nettee/common/validation/model/ValidationMapBuilder.java
+++ b/common/src/main/java/nettee/common/validation/model/ValidationMapBuilder.java
@@ -1,0 +1,27 @@
+package nettee.common.validation.model;
+
+import nettee.common.validation.model.interfaces.BaseValidationProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ValidationMapBuilder {
+    private final Map<String, BaseValidationProperty> map;
+
+    private ValidationMapBuilder() {
+        this.map = new HashMap<>();
+    }
+
+    public static ValidationMapBuilder builder() {
+        return new ValidationMapBuilder();
+    }
+
+    public ValidationMapBuilder put(String fieldName, BaseValidationProperty validation) {
+        map.put(fieldName, validation);
+        return this;
+    }
+
+    public Map<String, BaseValidationProperty> build() {
+        return Map.copyOf(map);
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/ValidationResponseModel.java
+++ b/common/src/main/java/nettee/common/validation/model/ValidationResponseModel.java
@@ -1,10 +1,12 @@
 package nettee.common.validation.model;
 
+import lombok.Builder;
 import nettee.common.validation.model.interfaces.BaseValidationProperty;
 
 import java.time.Instant;
 import java.util.Map;
 
+@Builder
 public record ValidationResponseModel(
         Map<String, BaseValidationProperty> validations,
         Instant serverTime,

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
@@ -1,0 +1,185 @@
+package nettee.blolet.draft.api.validation;
+
+import nettee.blolet.draft.api.validation.context.DraftContextValidationSupplier;
+import nettee.common.validation.model.StringValidationProperty;
+import nettee.common.validation.model.ValidationMapBuilder;
+import nettee.common.validation.model.ValidationResponseModel;
+import nettee.common.validation.model.interfaces.BaseValidationProperty;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.DraftValidationContexts.DRAFT_CONTEXT_CREATE;
+import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.DraftValidationContexts.DRAFT_CONTEXT_PATCH;
+import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.TargetFields.DRAFT_BLOG_ID;
+import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.TargetFields.DRAFT_ENTRY_BLOCK_ID;
+import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.TargetFields.DRAFT_PATH;
+import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.TargetFields.DRAFT_TITLE;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MAX_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MIN_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
+
+/**
+ * 임시 글(Draft)의 작성(create) 및 수정(patch) 시 필요한 유효성 검증 규칙을
+ * 서버에서 정적으로 제공하는 컴포넌트입니다.
+ * <ul>
+ *     <li>{@code create} 컨텍스트: 신규 임시 글 생성 시 유효성 규칙</li>
+ *     <li>{@code patch} 컨텍스트: 기존 임시 글 수정 시 유효성 규칙</li>
+ * </ul>
+ *
+ * <br />모든 ValidationProperty는 불변 맵(unmodifiable map)으로 제공합니다.
+ * {@link #get(String)} 메서드 호출 시 context 값에 따라 올바른 규칙 집합을 반환합니다.
+ *
+ * <br />지원하지 않는 context를 입력하면 {@link AssertionError} 또는 {@link Error}를 발생시킵니다.
+ *
+ * @author merge-simpson
+ * @since 2025-08-23
+ */
+@Component
+public final class StaticDraftValidationSupplier implements DraftContextValidationSupplier {
+
+    private static final Map<String, BaseValidationProperty> DRAFT_CREATE_VALIDATION;
+    private static final Map<String, BaseValidationProperty> DRAFT_PATCH_VALIDATION;
+
+    private static final int TITLE_MIN_LENGTH = 3;
+    private static final int TITLE_MAX_LENGTH = 100;
+    private static final int PATH_MAX_LENGTH = 2000; // cuz' 레거시 호환성: 2083글자
+
+    /**
+     * 유효성을 마지막으로 수정한 시각(고정값)입니다.
+     */
+    private static final Instant LAST_UPDATED_AT = Instant.parse("2025-08-23T00:00:00.000Z");
+
+    static {
+        // generate validation properties
+        var blogIdValidation = StringValidationProperty.builder()
+                .required(true)
+                .messages(Map.of(REQUIRED, "블로그 식별 값이 필요합니다. 문제가 지속되면 문의하시기 바랍니다."))
+                .build();
+        var titleCreateValidation = StringValidationProperty.builder()
+                .required(false)
+                .minLength(TITLE_MIN_LENGTH)
+                .maxLength(TITLE_MAX_LENGTH)
+                .messages(Map.of(
+                        MIN_LENGTH, "제목은 " + TITLE_MIN_LENGTH + "글자 이상이어야 합니다.",
+                        MAX_LENGTH, "제목은 최대 " + TITLE_MAX_LENGTH + "글자 이하로 입력하여야 합니다."
+                ))
+                .build();
+        var titlePatchValidation = StringValidationProperty.builder()
+                .required(true)
+                .minLength(TITLE_MIN_LENGTH)
+                .maxLength(TITLE_MAX_LENGTH)
+                .messages(Map.of(
+                        MIN_LENGTH, "제목은 " + TITLE_MIN_LENGTH + "글자 이상이어야 합니다.",
+                        MAX_LENGTH, "제목은 최대 " + TITLE_MAX_LENGTH + "글자 이하로 입력하여야 합니다."
+                ))
+                .build();
+        var pathCreateValidation = StringValidationProperty.builder()
+                .required(false)
+                .maxLength(PATH_MAX_LENGTH)
+                .messages(Map.of(MAX_LENGTH, "URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다."))
+                .build();
+        var pathPatchValidation = StringValidationProperty.builder()
+                .required(true)
+                .maxLength(PATH_MAX_LENGTH)
+                .messages(Map.of(
+                        REQUIRED, "게시물의 URL 경로를 입력하세요.",
+                        MAX_LENGTH, "게시물 URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다."
+                ))
+                .build();
+        var entryBlockIdPatchValidation = StringValidationProperty.builder()
+                .required(true)
+                .messages(Map.of(REQUIRED, "첫 블록 아이디가 반드시 필요합니다. 문제가 지속되면 문의해 주세요."))
+                .build();
+
+        // as unmodifiable maps
+        DRAFT_CREATE_VALIDATION = ValidationMapBuilder.builder()
+                .put(DRAFT_BLOG_ID, blogIdValidation)
+                .put(DRAFT_TITLE, titleCreateValidation)
+                .put(DRAFT_PATH, pathCreateValidation)
+                .build();
+        DRAFT_PATCH_VALIDATION = ValidationMapBuilder.builder()
+                .put(DRAFT_BLOG_ID, blogIdValidation)
+                .put(DRAFT_TITLE, titlePatchValidation)
+                .put(DRAFT_PATH, pathPatchValidation)
+                .put(DRAFT_ENTRY_BLOCK_ID, entryBlockIdPatchValidation)
+                .build();
+    }
+
+    /**
+     * Returns the validation response model based on the given context.
+     *
+     * @param context must be one of ("create") or ("patch").
+     *                Can use {@link DraftValidationContexts#DRAFT_CONTEXT_CREATE}
+     *                or {@link DraftValidationContexts#DRAFT_CONTEXT_PATCH}
+     * @return validation response model containing validation rules and metadata
+     * @throws AssertionError if context is not supported
+     */
+    @Override
+    public ValidationResponseModel get(String context) {
+        assert Set.of(DRAFT_CONTEXT_CREATE, DRAFT_CONTEXT_PATCH).contains(context)
+                : "Unsupported context: " + context + ". Supported values are 'create' or 'patch'. \n"
+                + "지원하지 않는 context 값입니다: " + context + ". 지원하는 값은 'create' 또는 'patch' 입니다.";
+
+        return switch (context) {
+            case DRAFT_CONTEXT_CREATE -> getCreateValidationModel();
+            case DRAFT_CONTEXT_PATCH -> getPatchValidationModel();
+            default -> throw new Error(
+                    "Supported values are 'create' or 'patch'. \n"
+                            + "지원하지 않는 context 값입니다. 지원하는 값은 'create' 또는 'patch' 입니다. \n"
+                            + "문제 지속 시, 문의는 뽀도가 먹꼬 찌푼뎅."
+            );
+        };
+    }
+
+    /**
+     * Returns the validation rules for draft creation.
+     *
+     * @return validation response model for {@code create} context
+     */
+    @Override
+    public ValidationResponseModel getCreateValidationModel() {
+        return ValidationResponseModel.builder()
+                .validations(DRAFT_CREATE_VALIDATION)
+                .lastUpdatedAt(LAST_UPDATED_AT)
+                .serverTime(Instant.now())
+                .build();
+    }
+
+    /**
+     * Returns the validation rules for draft patching.
+     *
+     * @return validation response model for {@code patch} context
+     */
+    @Override
+    public ValidationResponseModel getPatchValidationModel() {
+        return ValidationResponseModel.builder()
+                .validations(DRAFT_PATCH_VALIDATION)
+                .lastUpdatedAt(LAST_UPDATED_AT)
+                .serverTime(Instant.now())
+                .build();
+    }
+
+    /**
+     * Defines supported draft validation contexts.
+     * <p>지원하는 context 상수 모음: {@code create}, {@code patch}.
+     */
+    public static final class DraftValidationContexts {
+        public static final String DRAFT_CONTEXT_CREATE = "create";
+        public static final String DRAFT_CONTEXT_PATCH = "patch";
+    }
+
+    /**
+     * Defines field names used in draft validation.
+     * <p>유효성 검증 대상 필드명 상수 모음:
+     * {@code blogId}, {@code title}, {@code path}, {@code entryBlockId}.
+     */
+    static final class TargetFields {
+        static final String DRAFT_BLOG_ID = "blogId";
+        static final String DRAFT_TITLE = "title";
+        static final String DRAFT_PATH = "path";
+        static final String DRAFT_ENTRY_BLOCK_ID = "entryBlockId";
+    }
+}

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
@@ -21,6 +21,10 @@ import static nettee.common.validation.model.interfaces.BaseValidationProperty.R
 import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MIN_LENGTH;
 import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
 
+// NOTE: 정책의 DB 의존성 등 동적인 갱신 필요성 여부에 따른 아키텍처
+//  도메인중심적으로 정책 제공 시(재배포를 통해서만 제공 시) API 모듈이 가장 적합해 보이고,
+//  DB 의존 시 application(port)-adapter 구조가 적합할 수도 있음.
+//  (DB에서 직접 조회해서 주는 것이 아니더라도, DB 갱신 시 객체가 새 정책을 주입받을 수 있어야 함.)
 /**
  * 임시 글(Draft)의 작성(create) 및 수정(patch) 시 필요한 유효성 검증 규칙을
  * 서버에서 정적으로 제공하는 컴포넌트입니다.

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/context/DraftContextValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/context/DraftContextValidationSupplier.java
@@ -1,0 +1,7 @@
+package nettee.blolet.draft.api.validation.context;
+
+import nettee.common.validation.model.ValidationResponseModel;
+
+public interface DraftContextValidationSupplier extends DraftCreateValidationSupplier, DraftPatchValidationSupplier {
+    ValidationResponseModel get(String context);
+}

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/context/DraftCreateValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/context/DraftCreateValidationSupplier.java
@@ -1,0 +1,7 @@
+package nettee.blolet.draft.api.validation.context;
+
+import nettee.common.validation.model.ValidationResponseModel;
+
+public interface DraftCreateValidationSupplier {
+    ValidationResponseModel getCreateValidationModel();
+}

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/context/DraftPatchValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/context/DraftPatchValidationSupplier.java
@@ -1,0 +1,7 @@
+package nettee.blolet.draft.api.validation.context;
+
+import nettee.common.validation.model.ValidationResponseModel;
+
+public interface DraftPatchValidationSupplier {
+    ValidationResponseModel getPatchValidationModel();
+}


### PR DESCRIPTION
## Issues

- Resolves #302 

## Description

- Draft 유효성 정책을 정적으로 제공하는 구현체를 지원합니다.
- Rel: #298 

<br />

## Review Points

- 구조는 다음과 같습니다.

```mermaid
classDiagram
direction TB

%% ===== 빌더 =====
class ValidationMapBuilder {
  <<final>>
  -map Map~String,BaseValidationProperty~
  +builder() ValidationMapBuilder
  +put(fieldName, validation) ValidationMapBuilder
  +build() Map~String,BaseValidationProperty~
}

%% ===== Draft API - 인터페이스 계층 =====
class DraftCreateValidationSupplier {
  <<interface>>
  +getCreateValidationModel() ValidationResponseModel
}

class DraftPatchValidationSupplier {
  <<interface>>
  +getPatchValidationModel() ValidationResponseModel
}

class DraftContextValidationSupplier {
  <<interface>>
  +get(context String) ValidationResponseModel
}

DraftCreateValidationSupplier <|.. DraftContextValidationSupplier
DraftPatchValidationSupplier <|.. DraftContextValidationSupplier

%% ===== Draft API - 구현체 =====
class StaticDraftValidationSupplier {
  <<component>>
  -DRAFT_CREATE_VALIDATION Map~String,BaseValidationProperty~
  -DRAFT_PATCH_VALIDATION Map~String,BaseValidationProperty~
  -TITLE_MIN_LENGTH int
  -TITLE_MAX_LENGTH int
  -PATH_MAX_LENGTH int
  -LAST_UPDATED_AT Instant
  +get(context String) ValidationResponseModel
  +getCreateValidationModel() ValidationResponseModel
  +getPatchValidationModel() ValidationResponseModel
}

DraftContextValidationSupplier <|.. StaticDraftValidationSupplier
ValidationMapBuilder <.. StaticDraftValidationSupplier : uses
```

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

_No response_
