### PR TITLE
Common > Validation: 문자열 정규 표현식 응답 구조를 추가합니다.

### DIFF
--- a/common/src/main/java/nettee/common/validation/model/RegExpFlagBuilder.java
+++ b/common/src/main/java/nettee/common/validation/model/RegExpFlagBuilder.java
@@ -1,5 +1,6 @@
 package nettee.common.validation.model;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,6 +16,11 @@ public final class RegExpFlagBuilder {
 
     public RegExpFlagBuilder add(RegexpFlag flag) {
         flags.add(flag);
+        return this;
+    }
+
+    public RegExpFlagBuilder addAll(Collection<RegexpFlag> flags) {
+        this.flags.addAll(flags);
         return this;
     }
 

--- a/common/src/main/java/nettee/common/validation/model/RegExpFlagBuilder.java
+++ b/common/src/main/java/nettee/common/validation/model/RegExpFlagBuilder.java
@@ -1,0 +1,38 @@
+package nettee.common.validation.model;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class RegExpFlagBuilder {
+    private final Set<RegexpFlag> flags = new HashSet<>();
+
+    private RegExpFlagBuilder() {}
+
+    public static RegExpFlagBuilder builder() {
+        return new RegExpFlagBuilder();
+    }
+
+    public RegExpFlagBuilder add(RegexpFlag flag) {
+        flags.add(flag);
+        return this;
+    }
+
+    public String build() {
+        return String.join("", flags.stream()
+                .map(RegexpFlag::value)
+                .collect(Collectors.toSet())
+        );
+    }
+
+    public enum RegexpFlag {
+        S,
+        U,
+        M,
+        I;
+
+        public String value() {
+            return name().toLowerCase();
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/RegExpFlagBuilder.java
+++ b/common/src/main/java/nettee/common/validation/model/RegExpFlagBuilder.java
@@ -24,6 +24,11 @@ public final class RegExpFlagBuilder {
         return this;
     }
 
+    public RegExpFlagBuilder remove(RegexpFlag flag) {
+        flags.remove(flag);
+        return this;
+    }
+
     public String build() {
         return String.join("", flags.stream()
                 .map(RegexpFlag::value)

--- a/common/src/main/java/nettee/common/validation/model/StringValidationProperty.java
+++ b/common/src/main/java/nettee/common/validation/model/StringValidationProperty.java
@@ -3,6 +3,7 @@ package nettee.common.validation.model;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import nettee.common.validation.model.interfaces.LengthValidationProperty;
+import nettee.common.validation.model.interfaces.RegexpSpec;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +18,7 @@ import static nettee.common.validation.model.interfaces.BaseValidationProperty.R
 public record StringValidationProperty(
         String type,
         Boolean required,
-        String regexp,
+        RegexpSpec regexp,
         Integer minLength,
         Integer maxLength,
         Map<String, String> messages
@@ -36,11 +37,6 @@ public record StringValidationProperty(
             required = false;
         }
 
-        // empty (or blank) to null
-        if (regexp != null && regexp.isBlank()) {
-            regexp = null;
-        }
-
         // 둘 다 존재한다면 min < max (where, 둘 다 음수가 아님.)
         assert minLength == null || maxLength == null || (minLength >= 0 && maxLength >= 0 && minLength <= maxLength)
                 : "Invalid length bounds: minLength must be >= 0, maxLength must be >= 0, and minLength <= maxLength.";
@@ -53,7 +49,7 @@ public record StringValidationProperty(
             messages.put(REQUIRED, "필수 입력 항목입니다.");
         }
 
-        if (regexp != null && !regexp.isBlank() && !messages.containsKey(REGEXP)) {
+        if (regexp != null && !messages.containsKey(REGEXP)) {
             log.warn("정규표현식의 안내 메시지가 필요합니다.");
             messages.put(REGEXP, "올바른 입력 양식이 아닙니다.");
         }

--- a/common/src/main/java/nettee/common/validation/model/interfaces/RegexpSpec.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/RegexpSpec.java
@@ -1,0 +1,51 @@
+package nettee.common.validation.model.interfaces;
+
+import lombok.Builder;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.DOTALL;
+import static java.util.regex.Pattern.MULTILINE;
+import static java.util.regex.Pattern.UNICODE_CHARACTER_CLASS;
+import static nettee.common.validation.Preconditions.validateRegex;
+import static nettee.common.validation.model.interfaces.ValidationPreparationErrorCode.INVALID_REGEXP_PATTERN;
+import static nettee.common.validation.model.interfaces.ValidationPreparationErrorCode.UNSUPPORTED_REGEXP_FLAG;
+
+@Builder
+public record RegexpSpec(
+        String pattern,
+        String flags
+) {
+    public RegexpSpec {
+        assert pattern != null : "The 'pattern' must not be null or blank.";
+
+        if (flags == null) {
+            flags = "u";
+        }
+        validateRegex(flags, "^[sumi]*$", UNSUPPORTED_REGEXP_FLAG);
+
+        try {
+            // Bits:
+            //  s 0010 0000 (32)
+            //  u 0100 0000 (64)
+            //  m 0000 1000 ( 8)
+            //  i 0000 0010 ( 2)
+            int flagInt = flags.chars()
+                    .map((ch) -> switch (ch) {
+                        case 's' -> DOTALL;
+                        case 'u' -> UNICODE_CHARACTER_CLASS; // NOTE UNICODE_CLASS 대신 UNICODE_CHARACTER_CLASS 사용할 것.
+                        case 'm' -> MULTILINE;
+                        case 'i' -> CASE_INSENSITIVE;
+                        default -> throw UNSUPPORTED_REGEXP_FLAG.exception();
+                    })
+                    .reduce(0, (a,b) -> a | b);
+
+            //noinspection MagicConstant
+            Pattern.compile(pattern, flagInt);
+        } catch (PatternSyntaxException e) {
+            throw INVALID_REGEXP_PATTERN.exception(e);
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/ValidationPreparationErrorCode.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/ValidationPreparationErrorCode.java
@@ -1,0 +1,67 @@
+package nettee.common.validation.model.interfaces;
+
+import nettee.common.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public enum ValidationPreparationErrorCode implements ErrorCode {
+    UNSUPPORTED_REGEXP_FLAG(
+            HttpStatus.INTERNAL_SERVER_ERROR, // 백엔드에서만 입력한다는 전제에서.
+            "지원하지 않는 정규 표현식 플래그가 사용되었습니다. 문제가 지속되면 문의해 주세요."
+    ),
+    INVALID_REGEXP_PATTERN(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "올바른 정규표현식 입력 양식이 아닙니다."
+    )
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ValidationPreparationErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public ValidationPreparationException exception() {
+        return new ValidationPreparationException(this);
+    }
+
+    @Override
+    public ValidationPreparationException exception(Throwable cause) {
+        return new ValidationPreparationException(this, cause);
+    }
+
+    @Override
+    public ValidationPreparationException exception(Runnable runnable) {
+        return new ValidationPreparationException(this, runnable);
+    }
+
+    @Override
+    public ValidationPreparationException exception(Runnable runnable, Throwable cause) {
+        return new ValidationPreparationException(this, runnable, cause);
+    }
+
+    @Override
+    public ValidationPreparationException exception(Supplier<Map<String, Object>> appendPayload) {
+        return new ValidationPreparationException(this, appendPayload);
+    }
+
+    @Override
+    public ValidationPreparationException exception(Supplier<Map<String, Object>> appendPayload, Throwable cause) {
+        return new ValidationPreparationException(this, appendPayload, cause);
+    }
+}

--- a/common/src/main/java/nettee/common/validation/model/interfaces/ValidationPreparationException.java
+++ b/common/src/main/java/nettee/common/validation/model/interfaces/ValidationPreparationException.java
@@ -1,0 +1,57 @@
+package nettee.common.validation.model.interfaces;
+
+import nettee.common.CustomException;
+import nettee.common.ErrorCode;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ValidationPreparationException extends CustomException {
+    public ValidationPreparationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ValidationPreparationException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    public ValidationPreparationException(ErrorCode errorCode, Runnable runnable) {
+        super(errorCode, runnable);
+    }
+
+    public ValidationPreparationException(ErrorCode errorCode, Runnable runnable, Throwable cause) {
+        super(errorCode, runnable, cause);
+    }
+
+    public ValidationPreparationException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier) {
+        super(errorCode, payloadSupplier);
+    }
+
+    public ValidationPreparationException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        super(errorCode, payloadSupplier, cause);
+    }
+
+    public ValidationPreparationException() {
+        super();
+    }
+
+    public ValidationPreparationException(Throwable cause) {
+        super(cause);
+    }
+
+    public ValidationPreparationException(Runnable runnable) {
+        super(runnable);
+    }
+
+    public ValidationPreparationException(Runnable runnable, Throwable cause) {
+        super(runnable, cause);
+    }
+
+    public ValidationPreparationException(Supplier<Map<String, Object>> payloadSupplier) {
+        super(payloadSupplier);
+    }
+
+    public ValidationPreparationException(Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        super(payloadSupplier, cause);
+    }
+}


### PR DESCRIPTION
## Issues

- Resolves #338 

## Description

- 문자열 정규표현식 구조를 프론트엔드와 협의한 내용에 맞추어 제공합니다.  
  - `regexp` 안에 `{pattern, flags}` 구조
  - 각각 단일 문자열 필드로 제공
  - 플래그: `"sumi"` 중 0글자 이상
  - 플래그 생략 시 `"u"`로 취급 (`null` to `"u"`, empty 문자열은 유지)
  ```json
  {
    "regexp": {
      "pattern": "...",
      "flags": "..."
    }
  }
  ```

<br />

## Review Points

- `RegexpSpec` 위주로 봐 주시면 됩니다!

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

_No response_