### PR TITLE
Auth: 토큰 리프레시

### DIFF
--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
@@ -1,5 +1,6 @@
 package nettee.blolet.jwt.filter;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -37,15 +38,15 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                   HttpServletResponse response,
                                   FilterChain filterChain) throws IOException, ServletException {
-        
+
         String requestURI = request.getRequestURI();
         String method = request.getMethod();
-        
+
         // 1. Authorization 헤더에서 JWT 토큰 추출
         String jwtToken = extractJwtToken(request);
 
         // 2. JWT 토큰이 없으면 401 Unauthorized 응답
-        if (jwtToken == null) {
+        if (!StringUtils.hasText(jwtToken)) {
             log.warn("JWT 토큰이 존재하지 않습니다. [{}]: {}", method, requestURI);
             sendUnauthorizedResponse(response, "JWT 토큰이 존재하지 않습니다.", "Authorization 헤더에 JWT 토큰이 존재하지 않습니다.");
             return;
@@ -56,19 +57,32 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             var claims = jwtParser.parseClaims(jwtToken);
 
             // 4. JWT 토큰에서 사용자 정보 추출
-            request.setAttribute("userId", claims.getSubject());
-            request.setAttribute("roles", claims.get("roles", List.class));
-            request.setAttribute("profileIds", claims.get("profileIds", List.class));
+            setRequestAttribute(request, claims);
 
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
-            log.warn("JWT 토큰이 만료되었습니다.");
-            sendUnauthorizedResponse(response, "JWT 토큰이 만료되었습니다.", e.getMessage());
-
+            // 토큰이 만료된 경우, 리프레시 토큰 요청 경로는 통과
+            if (requestURI.equals("/auth/token/refresh")) {
+                var claims = e.getClaims();
+                setRequestAttribute(request, claims);
+                filterChain.doFilter(request, response);
+            } else {
+                log.warn("JWT 토큰이 만료되었습니다.");
+                sendUnauthorizedResponse(response, "JWT 토큰이 만료되었습니다.", e.getMessage());
+            }
         } catch (JwtException e) {
             log.error("JWT 토큰이 유효하지 않습니다.");
             sendUnauthorizedResponse(response, "JWT 토큰이 유효하지 않습니다.", e.getMessage());
         }
+    }
+
+    /**
+     * JWT 토큰에서 사용자 정보를 추출하여 요청 속성에 설정합니다.
+     */
+    private void setRequestAttribute(HttpServletRequest request, Claims claims) {
+        request.setAttribute("userId", claims.getSubject());
+        request.setAttribute("roles", claims.get("roles", List.class));
+        request.setAttribute("profileIds", claims.get("profileIds", List.class));
     }
 
     /**

--- a/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
+++ b/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
@@ -25,8 +25,6 @@ app:
           methods: "*"
         - path: "/auth/email/verification/check"
           methods: "*"
-        - path: "/auth/token/refresh"
-          methods: "*"
         # Blog
         - path: "/blogs/*/ownership"
           methods: "*"

--- a/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
+++ b/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
@@ -25,6 +25,7 @@ public enum AuthErrorCode implements ErrorCode {
     AUTH_OTP_INVALID("유효하지 않은 OTP 입니다.", HttpStatus.UNAUTHORIZED),
     AUTH_OTP_SERIALIZE_FAILED("OTP 직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AUTH_OTP_DESERIALIZE_FAILED("OTP 역직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AUTH_REFRESH_TOKEN_NOT_FOUND("리프레시 토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
 
     // rdb 관련 오류
     AUTH_USER_STATUS_INVALID("유효하지 않는 유저 상태입니다.", HttpStatus.BAD_REQUEST),

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthRedisPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthRedisPort.java
@@ -12,11 +12,10 @@ public interface AuthRedisPort {
     void delete(String key);
     void deleteAll(List<String> keys);
 
+    Boolean hasKey(String key);
+
     // Set operations
     void addToSet(String userSetKey, String hashedRefreshToken);
     void removeFromSet(String userSetKey, String hashedRefreshToken);
     Set<String> getSetMembers(String userSetKey);
-
-    Boolean hasKey(String key);
-    void updateTTL(String key, Duration ttl);
 }

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthRedisPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthRedisPort.java
@@ -8,6 +8,7 @@ public interface AuthRedisPort {
     // Key-Value operations
     void save(String key, String value, Duration ttl);
     String get(String key);
+
     void delete(String key);
     void deleteAll(List<String> keys);
 
@@ -15,4 +16,7 @@ public interface AuthRedisPort {
     void addToSet(String userSetKey, String hashedRefreshToken);
     void removeFromSet(String userSetKey, String hashedRefreshToken);
     Set<String> getSetMembers(String userSetKey);
+
+    Boolean hasKey(String key);
+    void updateTTL(String key, Duration ttl);
 }

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -6,6 +6,7 @@ import static nettee.auth.exception.AuthErrorCode.AUTH_ACCOUNT_LOGIN_FAILED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_DESERIALIZE_FAILED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_INVALID;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_SERIALIZE_FAILED;
+import static nettee.auth.exception.AuthErrorCode.AUTH_REFRESH_TOKEN_NOT_FOUND;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -95,7 +96,7 @@ public class AuthCommandService implements AuthSignUsecase {
         User userEntity = authCommandRepositoryPort.save(user);
 
         // 6. 회원가입 성공 시, 자동 로그인 처리를 위해 accessToken & refreshToken 발급
-        return generateLoginToken(userEntity);
+        return generateLoginToken(userEntity.getId());
     }
 
     @Override
@@ -110,7 +111,7 @@ public class AuthCommandService implements AuthSignUsecase {
         }
 
         // 3. 사용자 인증 성공 시, accessToken & refreshToken 발급
-        return generateLoginToken(userEntity);
+        return generateLoginToken(userEntity.getId());
     }
 
     @Override
@@ -198,33 +199,55 @@ public class AuthCommandService implements AuthSignUsecase {
         authCommandRepositoryPort.deleteById(userId);
     }
 
+    @Override
+    public String refreshAccessToken(String userId, String refreshToken) {
+        String hashedRefreshToken = hashSha256(refreshToken);
+        String hashedRefreshTokenKey = userId + ":" + hashedRefreshToken;
+        if (!authRedisPort.hasKey(hashedRefreshTokenKey)) {
+            throw new AuthException(AUTH_REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        // refreshToken 유효기간 연장
+        authRedisPort.updateTTL(hashedRefreshTokenKey, Duration.ofDays(REFRESH_TOKEN_EXPIRATION));
+
+        // refreshToken 유효한 경우, 새로운 accessToken 발급
+        return generateAccessToken(userId);
+    }
+
     /**
      * accessToken과 refreshToken을 발급합니다.
      * accessToken은 JWT 형식으로 발급되며, refreshToken은 암호화된 형태로 Redis에 저장합니다.
      */
-    private LoginTokenModel generateLoginToken(User userEntity) {
+    private LoginTokenModel generateLoginToken(String userId) {
         // accessToken 발급
-        Map<String, Object> claims = Map.of(
-                "userId", userEntity.getId()
-        );
-        String accessToken = jwtIssuer.issue(userEntity.getId(), claims, ACCESS_TOKEN_EXPIRATION);
+        String accessToken = generateAccessToken(userId);
 
         // refreshToken 발급
         String refreshToken = generateSecureRandom();
         String hashedRefreshToken = hashSha256(refreshToken);
 
         // refreshToken 저장
-        String hashedRefreshTokenKey = userEntity.getId() + ":" + hashedRefreshToken;
+        String hashedRefreshTokenKey = userId + ":" + hashedRefreshToken;
         authRedisPort.save(hashedRefreshTokenKey, hashedRefreshToken, Duration.ofDays(REFRESH_TOKEN_EXPIRATION));
 
         // 사용자별 토큰 관리를 위해 해시값을 Set에 저장
-        String userSetKey = "user_tokens:" + userEntity.getId();
+        String userSetKey = "user_tokens:" + userId;
         authRedisPort.addToSet(userSetKey, hashedRefreshToken);
 
         return LoginTokenModel.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    /**
+     * JWT 형식의 accessToken을 발급합니다.
+     */
+    private String generateAccessToken(String userId) {
+        Map<String, Object> claims = Map.of(
+                "userId", userId
+        );
+        return jwtIssuer.issue(userId, claims, ACCESS_TOKEN_EXPIRATION);
     }
 
     /**

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -200,18 +200,21 @@ public class AuthCommandService implements AuthSignUsecase {
     }
 
     @Override
-    public String refreshAccessToken(String userId, String refreshToken) {
+    public LoginTokenModel refreshAccessToken(String userId, String refreshToken) {
         String hashedRefreshToken = hashSha256(refreshToken);
         String hashedRefreshTokenKey = userId + ":" + hashedRefreshToken;
         if (!authRedisPort.hasKey(hashedRefreshTokenKey)) {
             throw new AuthException(AUTH_REFRESH_TOKEN_NOT_FOUND);
         }
 
-        // refreshToken 유효기간 연장
-        authRedisPort.updateTTL(hashedRefreshTokenKey, Duration.ofDays(REFRESH_TOKEN_EXPIRATION));
+        // 기존 refreshToken 삭제
+        authRedisPort.delete(hashedRefreshTokenKey);
 
-        // refreshToken 유효한 경우, 새로운 accessToken 발급
-        return generateAccessToken(userId);
+        String userSetKey = "user_tokens:" + userId;
+        authRedisPort.removeFromSet(userSetKey, hashedRefreshToken);
+
+        // 새로운 accessToken, refreshToken 발급
+        return generateLoginToken(userId);
     }
 
     /**

--- a/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
+++ b/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
@@ -12,4 +12,6 @@ public interface AuthSignUsecase {
 
     void logout(String userId, String refreshToken);
     void withdraw(String userId, String refreshToken);
+
+    String refreshAccessToken(String userId, String refreshToken);
 }

--- a/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
+++ b/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
@@ -13,5 +13,5 @@ public interface AuthSignUsecase {
     void logout(String userId, String refreshToken);
     void withdraw(String userId, String refreshToken);
 
-    String refreshAccessToken(String userId, String refreshToken);
+    LoginTokenModel refreshAccessToken(String userId, String refreshToken);
 }

--- a/services/auth/driven/redis/src/main/java/nettee/auth/redis/adapter/AuthRedisAdapter.java
+++ b/services/auth/driven/redis/src/main/java/nettee/auth/redis/adapter/AuthRedisAdapter.java
@@ -50,4 +50,15 @@ public class AuthRedisAdapter implements AuthRedisPort {
     public Set<String> getSetMembers(String userSetKey) {
         return stringRedisTemplate.opsForSet().members(userSetKey);
     }
+
+    @Override
+    public Boolean hasKey(String key) {
+        return stringRedisTemplate.hasKey(key);
+    }
+
+    @Override
+    public void updateTTL(String key, Duration ttl) {
+        stringRedisTemplate.expire(key, ttl);
+    }
+
 }

--- a/services/auth/driven/redis/src/main/java/nettee/auth/redis/adapter/AuthRedisAdapter.java
+++ b/services/auth/driven/redis/src/main/java/nettee/auth/redis/adapter/AuthRedisAdapter.java
@@ -37,6 +37,11 @@ public class AuthRedisAdapter implements AuthRedisPort {
     }
 
     @Override
+    public Boolean hasKey(String key) {
+        return stringRedisTemplate.hasKey(key);
+    }
+
+    @Override
     public void addToSet(String setKey, String value) {
         stringRedisTemplate.opsForSet().add(setKey, value);
     }
@@ -50,15 +55,4 @@ public class AuthRedisAdapter implements AuthRedisPort {
     public Set<String> getSetMembers(String userSetKey) {
         return stringRedisTemplate.opsForSet().members(userSetKey);
     }
-
-    @Override
-    public Boolean hasKey(String key) {
-        return stringRedisTemplate.hasKey(key);
-    }
-
-    @Override
-    public void updateTTL(String key, Duration ttl) {
-        stringRedisTemplate.expire(key, ttl);
-    }
-
 }

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -153,10 +153,10 @@ public class AuthCommandApi {
     )
     public ResponseEntity<LoginResponse> refreshAccessToken(@AuthUser AuthorizedUser authorizedUser,
                                             @CookieValue("refreshToken") String refreshToken) {
-        String accessToken = authSignUsecase.refreshAccessToken(authorizedUser.userId(), refreshToken);
-        LoginResponse result = new LoginResponse(accessToken);
+        LoginTokenModel responseModel = authSignUsecase.refreshAccessToken(authorizedUser.userId(), refreshToken);
+        LoginResponse result = mapper.toDto(responseModel);
 
-        ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(refreshToken); // 리프레시 토큰 유효기간 갱신
+        ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(responseModel.refreshToken());
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -151,9 +151,16 @@ public class AuthCommandApi {
             summary = "액세스 토큰 재발급",
             description = "리프레시 토큰(HttpOnly 쿠키)을 이용해 새로운 액세스 토큰을 발급받습니다."
     )
-    public LoginResponse refreshAccessToken(@CookieValue("refreshToken") String refreshToken) {
-        // 액세스 토큰 재발급 로직 구현
-        return null;
+    public ResponseEntity<LoginResponse> refreshAccessToken(@AuthUser AuthorizedUser authorizedUser,
+                                            @CookieValue("refreshToken") String refreshToken) {
+        String accessToken = authSignUsecase.refreshAccessToken(authorizedUser.userId(), refreshToken);
+        LoginResponse result = new LoginResponse(accessToken);
+
+        ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(refreshToken); // 리프레시 토큰 유효기간 갱신
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(result);
     }
 
     // TODO: 아이디/비밀번호 찾기 추가 기능 구현 가능성 있음


### PR DESCRIPTION
## Issues

- Resolves #343 
- Resolves #344 
- Resolves #345 

## Description

- 토큰 리프레시 기능을 구현했습니다.
- 액세스 토큰 만료 시 액세스 토큰과 리프레시 토큰을 재발급하도록 구현했습니다.
  - **자주 접속하는 사용자의 편의성**과 **리프레시 토큰의 물리적 유출 및 보안**을 고려해, 리프레시 토큰 또한 재발급하는 방식으로 구현했습니다!

- Redis에서 리프레시 토큰 조회를 하기 위해서, jwt-filter에서의 userId 설정이 필요합니다.
  - redis에서의 리프레시 토큰 key 형식이 `userId:hashedRefreshToken` 입니다.
  - 따라서 jwt-filter exclude path에서 `auth/token/refresh` API 경로를 제거하고, 만료된 JWT 토큰임에도 해당 경로일 시 userId 속성을 추가하도록 수정하였습니다.

<br />

## Review Points

- 자유로운 리뷰 부탁드립니다.

<br />

## How Has This Been Tested?

- Postman API 테스트를 통해 정상적으로 동작함을 확인하였습니다.
