### PR TITLE
Draft > API: Draft URL 경로에 정규표현식 유효성 정책을 적용합니다.

### DIFF
--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
@@ -1,10 +1,13 @@
 package nettee.blolet.draft.api.validation;
 
 import nettee.blolet.draft.api.validation.context.DraftContextValidationSupplier;
+import nettee.common.validation.model.RegExpFlagBuilder;
+import nettee.common.validation.model.RegExpFlagBuilder.RegexpFlag;
 import nettee.common.validation.model.StringValidationProperty;
 import nettee.common.validation.model.ValidationMapBuilder;
 import nettee.common.validation.model.ValidationResponseModel;
 import nettee.common.validation.model.interfaces.BaseValidationProperty;
+import nettee.common.validation.model.interfaces.RegexpSpec;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -19,6 +22,7 @@ import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.T
 import static nettee.blolet.draft.api.validation.StaticDraftValidationSupplier.TargetFields.DRAFT_TITLE;
 import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MAX_LENGTH;
 import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.MIN_LENGTH;
+import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REGEXP;
 import static nettee.common.validation.model.interfaces.BaseValidationProperty.ReservedFieldNames.REQUIRED;
 
 // NOTE: 정책의 DB 의존성 등 동적인 갱신 필요성 여부에 따른 아키텍처
@@ -50,6 +54,14 @@ public final class StaticDraftValidationSupplier implements DraftContextValidati
     private static final int TITLE_MIN_LENGTH = 3;
     private static final int TITLE_MAX_LENGTH = 100;
     private static final int PATH_MAX_LENGTH = 2000; // cuz' 레거시 호환성: 2083글자
+    private static final RegexpSpec PATH_REGEXP = RegexpSpec.builder()
+            .pattern("^[\\p{L}\\p{N}\\p{M}\\p{S}](?:[\\p{L}\\p{N}\\p{M}\\p{S}_-]*[\\p{L}\\p{N}\\p{M}\\p{S}])?$")
+            .flags(
+                    RegExpFlagBuilder.builder()
+                            .add(RegexpFlag.U)
+                            .build()
+            )
+            .build();
 
     /**
      * 유효성을 마지막으로 수정한 시각(고정값)입니다.
@@ -83,11 +95,17 @@ public final class StaticDraftValidationSupplier implements DraftContextValidati
         var pathCreateValidation = StringValidationProperty.builder()
                 .required(false)
                 .maxLength(PATH_MAX_LENGTH)
-                .messages(Map.of(MAX_LENGTH, "URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다."))
+                .regexp(PATH_REGEXP)
+                .messages(Map.of(
+                        MAX_LENGTH, "게시물 URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다.",
+                        REGEXP, "게시물 URL은 문자(한글·영문 등), 숫자, 기호(이모지 포함), 밑줄(_)과 하이픈(-)을 포함할 수 있습니다. "
+                                + "단, 시작과 끝에는 밑줄(_)이나 하이픈(-)이 올 수 없습니다."
+                ))
                 .build();
         var pathPatchValidation = StringValidationProperty.builder()
                 .required(true)
                 .maxLength(PATH_MAX_LENGTH)
+                .regexp(PATH_REGEXP)
                 .messages(Map.of(
                         REQUIRED, "게시물의 URL 경로를 입력하세요.",
                         MAX_LENGTH, "게시물 URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다."


### PR DESCRIPTION
> **이 PR을 리뷰하시면 #339, #340 PR을 리뷰하지 않아도 됩니다.**
> 단, 나눠서 리뷰하시는 것이 편리합니다.
> 
> - #339 
> - #340 

## Issues

- Resolves #341 

## Description

<a id="url-path-planning-deref-a"></a>
- [URL 경로 정책](#url-path-planning)에 맞추어 작업했습니다. <sup>[[1]](#url-path-planning)</sup>
- Rel: #298 

<br />

## Review Points

- `StaticDraftValidationSupplier`의 `PATH_REGEXP` 위주로 살펴봐 주시면 됩니다.  
  ```java
  private static final RegexpSpec PATH_REGEXP = RegexpSpec.builder()
          .pattern("^[\\p{L}\\p{N}\\p{M}\\p{S}](?:[\\p{L}\\p{N}\\p{M}\\p{S}_-]*[\\p{L}\\p{N}\\p{M}\\p{S}])?$")
          .flags(
                  RegExpFlagBuilder.builder()
                          .add(RegexpFlag.U)
                          .build()
          )
          .build();
  ```

<br />

## How Has This Been Tested?

- 테스트 생략

<br />

## Additional Notes

<a id="url-path-planning"></a>

### URL Path 정책 <sup>Deref: [[a] Description](#url-path-planning-deref-a)</sup>

사용자가 커스텀할 수 있는 URL 경로는 다음 규칙을 따릅니다.

- **<ins>모든 국가의 문자를</ins>** 허용합니다.  
  > 마침 설정하기가 일부 언어만 허용하는 것보다 더욱 편리하여 기술적 이유로 허용하기로 했습니다.  
- <ins>**결합 문자**(combining marks)</ins>를 허용합니다. (모든 국가의 문자 허용과 독립적으로 제어 가능)
- **모든 숫자를** 허용합니다.
- **이모지를** 허용합니다.
- **언더스코어**(_) 및 **하이픈**(-)은 첫 자리와 끝자리만 제외하고 사용할 수 있습니다.

### 참고한 구조 (#340)

- `regexp` 안에 `{pattern, flags}` 구조로 제공합니다.
- 각각 단일 문자열 필드로 제공합니다.
- 플래그는 `"sumi"` 중 0글자 이상으로 합니다. (Empty 문자열 허용)
- 플래그가 `null` 또는 `undefined`일 때는 `u`로 취급합니다.
