### PR TITLE
Draft > RDB: 본문 이미지를 서버에 저장합니다.

### DIFF
--- a/services/draft/api/domain/src/main/java/nettee/draft/domain/DraftImage.java
+++ b/services/draft/api/domain/src/main/java/nettee/draft/domain/DraftImage.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Builder
 @Getter
@@ -17,5 +17,5 @@ public class DraftImage {
 
     private String imageUrl;
 
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 }

--- a/services/draft/api/exception/src/main/java/nettee/draft/exception/DraftErrorCode.java
+++ b/services/draft/api/exception/src/main/java/nettee/draft/exception/DraftErrorCode.java
@@ -16,7 +16,10 @@ public enum DraftErrorCode implements ErrorCode {
     DRAFT_GONE("더 이상 존재하지 않는 게시물입니다.", HttpStatus.GONE),
     DRAFT_FORBIDDEN("권한이 없습니다.", HttpStatus.FORBIDDEN),
     DRAFT_ALREADY_EXIST("임시글이 이미 존재합니다.", HttpStatus.CONFLICT),
-    DEFAULT("임시글 조작 오류", HttpStatus.INTERNAL_SERVER_ERROR);
+    DEFAULT("임시글 조작 오류", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // image status
+    DRAFT_IMAGE_SAVE_FAILED("임시글 이미지를 저장하는 데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/services/draft/api/exception/src/main/java/nettee/draft/exception/DraftErrorCode.java
+++ b/services/draft/api/exception/src/main/java/nettee/draft/exception/DraftErrorCode.java
@@ -11,15 +11,15 @@ public enum DraftErrorCode implements ErrorCode {
     DRAFT_BLOG_ID_REQUIRED("블로그 ID를 반드시 제공해야 합니다.", HttpStatus.BAD_REQUEST),
     DRAFT_TITLE_MIN_LENGTH("블로그 제목은 반드시 3글자 이상입니다.", HttpStatus.BAD_REQUEST),
 
+    // image status
+    DRAFT_IMAGE_SAVE_FAILED("임시글 이미지를 저장하는 데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
     // blog status
     DRAFT_NOT_FOUND("임시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DRAFT_GONE("더 이상 존재하지 않는 게시물입니다.", HttpStatus.GONE),
     DRAFT_FORBIDDEN("권한이 없습니다.", HttpStatus.FORBIDDEN),
     DRAFT_ALREADY_EXIST("임시글이 이미 존재합니다.", HttpStatus.CONFLICT),
-    DEFAULT("임시글 조작 오류", HttpStatus.INTERNAL_SERVER_ERROR),
-
-    // image status
-    DRAFT_IMAGE_SAVE_FAILED("임시글 이미지를 저장하는 데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    DEFAULT("임시글 조작 오류", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftCommandAdapter.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftCommandAdapter.java
@@ -1,6 +1,8 @@
 package nettee.draft.driven.rdb;
 
 import lombok.RequiredArgsConstructor;
+import nettee.draft.domain.DraftImage;
+import nettee.draft.driven.rdb.entity.DraftImageEntity;
 import nettee.draft.readmodel.DraftReadModels.DraftDetail;
 import nettee.draft.domain.Draft;
 import nettee.draft.driven.rdb.entity.type.DraftEntityStatus;
@@ -13,28 +15,31 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 import static nettee.draft.exception.DraftErrorCode.DEFAULT;
+import static nettee.draft.exception.DraftErrorCode.DRAFT_IMAGE_SAVE_FAILED;
 import static nettee.draft.exception.DraftErrorCode.DRAFT_NOT_FOUND;
 
 @Repository
 @RequiredArgsConstructor
 public class DraftCommandAdapter implements DraftCommandPort {
+
     private final DraftJpaRepository draftJpaRepository;
-    private final DraftEntityMapper draftEntityMapper;
+    private final DraftImageJpaRepository draftImageJpaRepository;
+    private final DraftEntityMapper mapper;
 
     @Override
     public Optional<DraftDetail> findById(String id) {
         var draft = draftJpaRepository.findById(id)
                 .orElseThrow(DRAFT_NOT_FOUND::exception);
-        return draftEntityMapper.toOptionalDraftDetail(draft);
+        return mapper.toOptionalDraftDetail(draft);
     }
 
     @Override
     public Draft save(Draft draft) {
-        var draftEntity = draftEntityMapper.toEntity(draft);
-        try{
+        var draftEntity = mapper.toEntity(draft);
+
+        try {
             var newDraft = draftJpaRepository.save(draftEntity);
-            draftJpaRepository.flush();
-            return draftEntityMapper.toDomain(newDraft);
+            return mapper.toDomain(newDraft);
         } catch (DataAccessException e) {
             throw DEFAULT.exception(e);
         }
@@ -44,6 +49,7 @@ public class DraftCommandAdapter implements DraftCommandPort {
     public Draft update(Draft draft) {
         var existDraft = draftJpaRepository.findById(draft.getId())
                             .orElseThrow(DRAFT_NOT_FOUND::exception);
+
         existDraft.prepareDraftEntityUpdate()
                 .title(draft.getTitle())
                 .content(draft.getContent())
@@ -51,16 +57,30 @@ public class DraftCommandAdapter implements DraftCommandPort {
                 .status(DraftEntityStatus.valueOf(draft.getStatus()))
                 .update();
 
-        return draftEntityMapper.toDomain(draftJpaRepository.save(existDraft));
+        return mapper.toDomain(draftJpaRepository.save(existDraft));
     }
 
     @Override
     public void updateStatus(String id, DraftStatus draftStatus) {
         var draft = draftJpaRepository.findById(id)
                     .orElseThrow(DRAFT_NOT_FOUND::exception);
+
         draft.prepareDraftEntityStatusUpdate()
                 .status(DraftEntityStatus.valueOf(draftStatus))
                 .updateStatus();
+
         draftJpaRepository.save(draft);
+    }
+
+    @Override
+    public DraftImage save(DraftImage draftImage) {
+        DraftImageEntity draftImageEntity = mapper.toEntity(draftImage);
+
+        try {
+            var newDraftImage= draftImageJpaRepository.save(draftImageEntity);
+            return mapper.toDomain(newDraftImage);
+        } catch (DataAccessException e) {
+            throw DRAFT_IMAGE_SAVE_FAILED.exception(e);
+        }
     }
 }

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftImageJpaRepository.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/DraftImageJpaRepository.java
@@ -1,0 +1,7 @@
+package nettee.draft.driven.rdb;
+
+import nettee.draft.driven.rdb.entity.DraftImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DraftImageJpaRepository extends JpaRepository<DraftImageEntity, String> {
+}

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftImageEntity.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/entity/DraftImageEntity.java
@@ -1,0 +1,19 @@
+package nettee.draft.driven.rdb.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import nettee.jpa.support.SnowflakeBaseTimeEntity;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(schema = "article", name = "draft_image")
+public class DraftImageEntity extends SnowflakeBaseTimeEntity {
+
+    public String imageUrl;
+}

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/persistence/mapper/DraftEntityMapper.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/persistence/mapper/DraftEntityMapper.java
@@ -1,6 +1,8 @@
 package nettee.draft.driven.rdb.persistence.mapper;
 
+import nettee.draft.domain.DraftImage;
 import nettee.draft.driven.rdb.entity.DraftEntity;
+import nettee.draft.driven.rdb.entity.DraftImageEntity;
 import nettee.draft.readmodel.DraftReadModels.DraftDetail;
 import nettee.draft.readmodel.DraftReadModels.DraftSummary;
 import nettee.draft.domain.Draft;
@@ -13,11 +15,14 @@ import java.util.Optional;
 
 @Mapper(componentModel = "spring")
 public interface DraftEntityMapper {
+
     Draft toDomain(DraftEntity draftEntity);
     DraftEntity toEntity(Draft draft);
     DraftDetail toDraftDetail(DraftEntity draftEntity);
     DraftSummary toDraftSummary(DraftEntity draftEntity);
     DraftTitle toDraftTitle(DraftEntity draftEntity);
+    DraftImage toDomain(DraftImageEntity draftImageEntity);
+    DraftImageEntity toEntity(DraftImage draftImage);
 
     default Optional<Draft> toOptionalDomain(DraftEntity draftEntity) {
         return Optional.ofNullable(toDomain(draftEntity));

--- a/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/persistence/mapper/DraftEntityMapper.java
+++ b/services/draft/driven/rdb/src/main/java/nettee/draft/driven/rdb/persistence/mapper/DraftEntityMapper.java
@@ -18,9 +18,11 @@ public interface DraftEntityMapper {
 
     Draft toDomain(DraftEntity draftEntity);
     DraftEntity toEntity(Draft draft);
+
     DraftDetail toDraftDetail(DraftEntity draftEntity);
     DraftSummary toDraftSummary(DraftEntity draftEntity);
     DraftTitle toDraftTitle(DraftEntity draftEntity);
+
     DraftImage toDomain(DraftImageEntity draftImageEntity);
     DraftImageEntity toEntity(DraftImage draftImage);
 


### PR DESCRIPTION
## Issues

- Resolves #315 

## Description
- DraftCommandAdapter에 DraftImage를 저장하는 메서드를 추가하고, 이미지 저장 실패 시 DRAFT_IMAGE_SAVE_FAILED 예외를 처리하도록 개선했습니다.

```java
// 어노테이션 생략
public class DraftImage {

    private Long id;

    private String imageUrl;

    private Instant createdAt;
}
```
- DraftImage 도메인 및 엔티티 내부에는 imageUrl(경로)만 존재합니다.
- 서버에 이미지(파일) 저장 후 -> 경로만 DB에 저장하는 방식

<br />

## Review Points

- 메서드 내부 로직 및 에러코드 위주로 확인해주시면 감사하겠습니다.

<br />

## How Has This Been Tested?

- 테스트 생략