### PR TITLE
Draft > WebMVC, Application: Draft 부가정보의 유효성 정책을 제공합니다.

### DIFF
--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
@@ -76,6 +76,7 @@ public final class StaticDraftValidationSupplier implements DraftContextValidati
                 .minLength(TITLE_MIN_LENGTH)
                 .maxLength(TITLE_MAX_LENGTH)
                 .messages(Map.of(
+                        REQUIRED, "제목을 입력하세요.",
                         MIN_LENGTH, "제목은 " + TITLE_MIN_LENGTH + "글자 이상이어야 합니다.",
                         MAX_LENGTH, "제목은 최대 " + TITLE_MAX_LENGTH + "글자 이하로 입력하여야 합니다."
                 ))

--- a/services/draft/application/build.gradle.kts
+++ b/services/draft/application/build.gradle.kts
@@ -1,13 +1,8 @@
-val draftDomain: String by project
-val draftException: String by project
-val draftReadModel: String by project
-
+val draftApi: String by project
 val blogClientWebMvc: String by project
 
 dependencies {
-    api(project(draftDomain))
-    api(project(draftException))
-    api(project(draftReadModel))
+    api(project(draftApi))
 
     // internal clients
     api(project(blogClientWebMvc))

--- a/services/draft/application/src/main/java/nettee/draft/application/service/DraftQueryService.java
+++ b/services/draft/application/src/main/java/nettee/draft/application/service/DraftQueryService.java
@@ -1,6 +1,9 @@
 package nettee.draft.application.service;
 
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.draft.api.validation.context.DraftContextValidationSupplier;
+import nettee.common.validation.model.ValidationResponseModel;
+import nettee.draft.application.usecase.DraftValidationResponseUseCase;
 import nettee.draft.readmodel.DraftReadModels.DraftDetail;
 import nettee.draft.readmodel.DraftReadModels.DraftSummary;
 import nettee.draft.application.port.DraftQueryPort;
@@ -8,10 +11,6 @@ import nettee.draft.domain.type.DraftStatus;
 import nettee.draft.application.usecase.DraftReadByStatusesUseCase;
 import nettee.draft.application.usecase.DraftReadUseCase;
 import nettee.draft.readmodel.DraftReadModels.DraftTitle;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,8 +20,10 @@ import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
-public class DraftQueryService implements DraftReadUseCase, DraftReadByStatusesUseCase {
+public class DraftQueryService implements DraftReadUseCase, DraftReadByStatusesUseCase, DraftValidationResponseUseCase {
+
     private final DraftQueryPort draftQueryPort;
+    private final DraftContextValidationSupplier draftContextValidationSupplier;
 
     @Override
     public Optional<DraftDetail> getDraft(String id) {
@@ -39,4 +40,8 @@ public class DraftQueryService implements DraftReadUseCase, DraftReadByStatusesU
         return draftQueryPort.findByStatuses(blogId, statuses, sortBy, ascending);
     }
 
+    @Override
+    public ValidationResponseModel responseValidation(String context) {
+        return draftContextValidationSupplier.get(context);
+    }
 }

--- a/services/draft/application/src/main/java/nettee/draft/application/usecase/DraftValidationResponseUseCase.java
+++ b/services/draft/application/src/main/java/nettee/draft/application/usecase/DraftValidationResponseUseCase.java
@@ -1,0 +1,7 @@
+package nettee.draft.application.usecase;
+
+import nettee.common.validation.model.ValidationResponseModel;
+
+public interface DraftValidationResponseUseCase {
+    ValidationResponseModel responseValidation(String context);
+}

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCustomPathQueryApi.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCustomPathQueryApi.java
@@ -1,0 +1,27 @@
+package nettee.draft.driving.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import nettee.common.validation.model.ValidationResponseModel;
+import nettee.draft.application.usecase.DraftValidationResponseUseCase;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Draft", description = "Draft API")
+public class DraftCustomPathQueryApi {
+    private final DraftValidationResponseUseCase validationResponseUseCase;
+
+    @GetMapping("/api/validations/draft")
+    @Operation(summary = "임시 글의 유효성 정책", description = "context를 입력받아 ")
+    public ValidationResponseModel responseValidation(
+            @Schema(name = "context", example = "create", description = "`create` 또는 `patch`를 지원합니다.")
+            @RequestParam("context") String context
+    ) {
+        return validationResponseUseCase.responseValidation(context);
+    }
+}

--- a/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCustomPathQueryApi.java
+++ b/services/draft/driving/web-mvc/src/main/java/nettee/draft/driving/web/DraftCustomPathQueryApi.java
@@ -1,6 +1,7 @@
 package nettee.draft.driving.web;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +18,9 @@ public class DraftCustomPathQueryApi {
     private final DraftValidationResponseUseCase validationResponseUseCase;
 
     @GetMapping("/api/validations/draft")
-    @Operation(summary = "임시 글의 유효성 정책", description = "context를 입력받아 ")
+    @Operation(summary = "임시 글의 유효성 정책", description = "context를 입력받아 드래프트 유효성 정책을 응답합니다.")
+    @Parameter(name = "context", description = "`create` 또는 `patch`를 지원합니다.", example = "create")
     public ValidationResponseModel responseValidation(
-            @Schema(name = "context", example = "create", description = "`create` 또는 `patch`를 지원합니다.")
             @RequestParam("context") String context
     ) {
         return validationResponseUseCase.responseValidation(context);


### PR DESCRIPTION

## Issues

- Resolves #300
- Resolves #301

## Description

### 작업 요약

- 드래프트 유효성 정책 조회 API 추가 (`/api/validations/draft`)
- draft-application에서 `draft-api` 모듈로 의존성 단순화

### 주요 기능

- 사용자로부터 전달받은 `context`별 `ValidationResponseModel`을 제공합니다.
- API 엔드포인트
  - `GET /api/validations/draft?context={create|patch}`
  - 반환: `ValidationResponseModel { "validations": {...}, "serverTime": "", "lastUpdatedAt": "" }`

### 기타 개선

- `draft-application`의 `build.gradle.kts`에서 `domain`/`exception`/`read-model` 직접 의존을 제거하고, `draft-api` 번들 모듈 의존으로 교체하여 중복 선언을 해소했습니다.
- 정적 검증 공급자(`StaticDraftValidationSupplier`)에 누락되었던 제목 필수 입력 유효성 메시지(`REQURED`)를 추가했습니다.

<br />

## Review Points

- API 계약
  - 엔드포인트/메서드/쿼리 파라미터: `GET /api/validations/draft?context=create|patch`
  - `context`에 허용되는 값과, 미지원 값 처리 방식(예외/기본값)을 확인해 주세요.
  - 응답 모델(`ValidationResponseModel`)의 필드 구조(특히 `validations` 맵의 키/값 스키마)를 검토해 주세요.
- OpenAPI 문서화: `@Schema`의 예시/설명

<br />

## How Has This Been Tested?

- 로컬 실행 후 Postman 및 Swagger UI로 육안으로 확인했습니다.
  - `GET /api/validations/draft?context=create`
  - `GET /api/validations/draft?context=patch`
- 응답 예시(발췌)  
  > <del>참고: 아직 정규표현식이 병합되지 않았을 때 예시입니다.  
  > 병합되면 추가 작업 없이 이하 응답이 수정됩니다.</del>
  > 정규표현식을 병합했습니다.
  ```json
  {
      "validations": {
          "blogId": {
              "type": "string",
              "required": true,
              "messages": {
                  "required": "블로그 식별 값이 필요합니다. 문제가 지속되면 문의하시기 바랍니다."
              }
          },
          "title": {
              "type": "string",
              "required": false,
              "minLength": 3,
              "maxLength": 100,
              "messages": {
                  "minLength": "제목은 3글자 이상이어야 합니다.",
                  "maxLength": "제목은 최대 100글자 이하로 입력하여야 합니다."
              }
          },
          "path": {
              "type": "string",
              "required": false,
              "regexp": {
                  "pattern": "^[\\p{L}\\p{N}\\p{M}\\p{S}](?:[\\p{L}\\p{N}\\p{M}\\p{S}_-]*[\\p{L}\\p{N}\\p{M}\\p{S}])?$",
                  "flags": "u"
              },
              "maxLength": 2000,
              "messages": {
                  "regexp": "게시물 URL은 문자(한글·영문 등), 숫자, 기호(이모지 포함), 밑줄(_)과 하이픈(-)을 포함할 수 있습니다. 단, 시작과 끝에는 밑줄(_)이나 하이픈(-)이 올 수 없습니다.",
                  "maxLength": "게시물 URL 경로의 최대 길이는 2000 글자입니다."
              }
          }
      },
      "serverTime": "2025-08-24T03:41:24.412511Z",
      "lastUpdatedAt": "2025-08-23T00:00:00Z"
  }
  ```
- 단위 테스트는 추후 유효/무효 context 케이스를 보강합니다. 현 단계에서는 빌드 및 수동 호출로 동작 확인했습니다.

<br />

## Additional Notes

- 향후 `context` 확장(예: `publish` 등) 시, 동일 패턴으로 확장할 수 있습니다.
