### PR TITLE
Monolith: 유효성 모델 요청 시 인증을 요구하지 않도록 합니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
+++ b/monolith/main-runner/src/main/resources/properties/jwt/blolet.jwt.filter.yml
@@ -11,11 +11,13 @@ app:
           methods: "*"
           description: |
             내부 API 경로
-        # Docs 등 static
+        # Docs 등
         - path: "/swagger-ui/**"
           methods: "*"
         - path: "/v3/api-docs/**"
           methods: "*"
+        - path: "/api/validations/**"
+          methods: "get"
         # Auth
         - path: "/auth/signup"
           methods: "*"

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
@@ -106,7 +106,9 @@ public final class StaticDraftValidationSupplier implements DraftContextValidati
                 .regexp(PATH_REGEXP)
                 .messages(Map.of(
                         REQUIRED, "게시물의 URL 경로를 입력하세요.",
-                        MAX_LENGTH, "게시물 URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다."
+                        MAX_LENGTH, "게시물 URL 경로의 최대 길이는 " + PATH_MAX_LENGTH + " 글자입니다.",
+                        REGEXP, "게시물 URL은 각국 언어, 각국 숫자, 기호(이모지 포함) 및 밑줄(_)과 하이픈(-)을 포함할 수 있습니다. "
+                                + "단, 시작과 끝에는 밑줄(_)이나 하이픈(-)이 올 수 없습니다."
                 ))
                 .build();
         var entryBlockIdPatchValidation = StringValidationProperty.builder()

--- a/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
+++ b/services/draft/api/src/main/java/nettee/blolet/draft/api/validation/StaticDraftValidationSupplier.java
@@ -39,7 +39,6 @@ import static nettee.common.validation.model.interfaces.BaseValidationProperty.R
  *
  * <br />모든 ValidationProperty는 불변 맵(unmodifiable map)으로 제공합니다.
  * {@link #get(String)} 메서드 호출 시 context 값에 따라 올바른 규칙 집합을 반환합니다.
- *
  * <br />지원하지 않는 context를 입력하면 {@link AssertionError} 또는 {@link Error}를 발생시킵니다.
  *
  * @author merge-simpson
@@ -75,7 +74,6 @@ public final class StaticDraftValidationSupplier implements DraftContextValidati
                 .messages(Map.of(REQUIRED, "블로그 식별 값이 필요합니다. 문제가 지속되면 문의하시기 바랍니다."))
                 .build();
         var titleCreateValidation = StringValidationProperty.builder()
-                .required(false)
                 .minLength(TITLE_MIN_LENGTH)
                 .maxLength(TITLE_MAX_LENGTH)
                 .messages(Map.of(
@@ -94,7 +92,6 @@ public final class StaticDraftValidationSupplier implements DraftContextValidati
                 ))
                 .build();
         var pathCreateValidation = StringValidationProperty.builder()
-                .required(false)
                 .maxLength(PATH_MAX_LENGTH)
                 .regexp(PATH_REGEXP)
                 .messages(Map.of(


### PR DESCRIPTION

## Issues

- Resolves #353
- Resolves #354

<br />

## Description

> 이 설명은 인공지능이 작성하였습니다.  
> 이 PR에 작업은 최큼 했는데 작업량 마케팅이 과장광고가 심하네요.

- **애플리케이션 계층**
  - `DraftValidationResponseUseCase` 신규 정의/구현: API 모듈의 `DraftContextValidationSupplier`를 사용하여 컨텍스트별 정책 제공
- **공통 모델/유틸**
  - `ValidationResponseModel`에 `@Builder` 추가, `serverTime` 기본값 Now 설정, `lastUpdatedAt` 포함
  - `ValidationMapBuilder` 추가로 필드명→검증정책 맵 구성 간결화
  - 정규식 플래그 표현 유틸 `RegExpFlagBuilder` 추가(`s`/`u`/`m`/`i`)
- **검증 정책 보강** (이번에 실제로 한 것: 여기서 메시지 추가)
  - 게시글 경로 정책 정교화: `PATH_REGEXP` 및 메시지 추가  
    - 패턴: `^[\p{L}\p{N}\p{M}\p{S}](?:[\p{L}\p{N}\p{M}\p{S}_-]*[\p{L}\p{N}\p{M}\p{S}])?$`  
    - 규칙: 시작/끝에는 `_` 또는 `-` 불가, 중간에는 허용. 전 세계 문자(문자 `\p{L}`·숫자 `\p{N}`·결합표식 `\p{M}`·기호 `\p{S}`) 지원
- **보안 예외 경로** (이번에 한 것)
  - `app.auth.filter.exclude-paths`에 `/api/validations/**`(`GET`) 추가
- **모듈 의존성 정리**
  - `draft-application`에서 API 모듈을 통해 번들된 의존성 활용(과잉 개별 의존성 제거)
- **설계 노트**
  - 정책 제공의 정적(재배포) vs 동적(DB 연동) 아키텍처 고려 주석 추가

- Compare: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/draft-webmvc-validation-response

<br />

## Review Points

> 이 리뷰 포인트는 인공지능이 작성하였습니다.

- **인가 우회 설정**
  - `/api/validations/**`의 **<ins>GET</ins>** 메서드만 인증 예외 처리한 것이 의도대로인지 (다른 메서드는 보호됨)
- **응답 스키마**
  - `ValidationResponseModel`의 `serverTime`/`lastUpdatedAt` 의미, 타임존 표준(UTC 권장) 및 테스트 결정성
- **정규식/플래그**
  - `PATH_REGEXP`의 경계 조건(이모지·결합문자·언더스코어/하이픈 규칙) 검토
  - `RegExpFlagBuilder(S/U/M/I)`의 소비자(프론트/클라이언트) 매핑 전략 문서화 필요 여부
- **모듈링**
  - API 모듈 의존 전환으로 인한 노출 범위/순환 참조 위험 여부
- **호환성**
  - 신규 엔드포인트 추가로 인한 기존 경로/필터와의 충돌 없음 확인

<br />

## How Has This Been Tested?

- **수기 점검**
  - Postman을 통해 육안으로 확인하였습니다.

> - **권장 테스트**
>   - 응답의 경로 필드 정책에 대해 샘플 입력(허용/비허용 케이스) 수동 확인을 추가할 수 있습니다.
>   - **유닛 테스트 (Kotest)**
>     - `DraftValidationResponseUseCase`가 `context=create|patch` 각각에 대해 예상 `validations` 맵을 반환하는지
>     - 알 수 없는 `context` 처리(명세에 따른 400 응답 혹은 디폴트 전략) 검증
>     - `ValidationResponseModel.builder()` 사용 시 `serverTime` 자동 설정 확인
>     - `RegExpFlagBuilder`가 `S/U/M/I` 조합을 중복 없이 직렬화하는지
>     - `ArrayValidationProperty` 타입 검증이 `'array'`로만 허용되는지
>   - **WebMVC 슬라이스 테스트 (MockMvc)**
>     - `GET /api/validations/draft?context=create` 200 OK 및 스키마 필드(`validations`, `serverTime`, `lastUpdatedAt`) 존재
>     - 인증 필터 예외: 위 경로 GET 호출이 인증 없이 **통과되는지**

<br />

## Additional Notes

> 이 부연 설명은 인공지능이 작성하였습니다.  

- **브레이킹 체인지 없음**: 신규 엔드포인트 추가만 포함
- **후속 작업 제안**
  - 정책 캐싱/ETag 및 버저닝(`lastUpdatedAt` 활용)
  - `context`를 enum 파라미터로 문서화 강화 및 잘못된 값에 대한 표준 에러 코드 부여
  - 정규식/플래그 소비자 가이드(프론트엔드 매핑 표) 문서화
  - OpenAPI 문구(요약/설명) 최종 통일
- **Compare 링크(재기재)**: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/draft-webmvc-validation-response