### PR TITLE
Feature/flyway

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/dummy/README.md
+++ b/monolith/main-runner/src/main/resources/db/migration/dummy/README.md
@@ -1,0 +1,121 @@
+# Dummy Data
+
+## Count
+
+<table>
+<tr>
+  <th>회원 생성 초기화</th>
+</tr>
+<tr>
+  <td>
+  
+  - `"auth"."user"`: 2
+  - `"profile"."profile"`: 2
+  - `"blog"."blog"`: 2
+  
+  </td>
+</tr>
+</table>
+
+<table>
+<tr>
+  <th>게시물 존재 초기화</th>
+</tr>
+<tr>
+  <td>
+  
+  - `"article"."draft"`: 115
+  - `PENDING`: 52
+  - `PUBLISHED`: 53
+  - `SUSPENDED`: 5
+  - `REMOVED`: 5
+  - `"article"."article"`: 63
+    - `ACTIVE`: 53
+    - `SUSPENDED`: 5
+    - `REMOVED`: 5
+  - `"series"."series"`: 53
+  - `"series"."series_article"`: 110
+    - Draft: 52
+    - Article: 58
+  
+  </td>
+</tr>
+</table>
+
+> 드래프트 블록은 아직 초기화하지 않았습니다.
+
+## Allocation
+
+사용자 1의 블로그에 모든 아티클, 드래프트, 시리즈가 존재합니다.
+
+```mermaid
+flowchart TD
+%% ─────────────────────────────
+%% 사용자/블로그별 더미데이터 개요
+%% ─────────────────────────────
+
+subgraph U1["사용자 1 (sun)"]
+    P1[프로필: 1개]
+    
+    subgraph B1["블로그 1 (sun)"]
+        subgraph D1["Draft: 115개"]
+            D_PEND1["Pending 52"]
+            D_PUB1["Published 53"]
+            D_SUS1["Suspended 5"]
+            D_REM1["Removed 5"]
+        end
+        subgraph A1["Article: 63개"]
+            A_ACT1["Active 53"]
+            A_SUS1["Suspended 5"]
+            A_REM1["Removed 5"]
+        end
+        subgraph SG1["시리즈: 53개"]
+            S1["시리즈 1"]
+        end
+        subgraph SAG1["시리즈-아티클 연결: 110개"]
+          SA1["Article 링크 58"]    
+          SD1["Draft 링크 52"]    
+        end
+        
+    end
+
+    P1 --> B1
+    B1 --> D1
+    B1 --> A1
+    B1 --> S1
+    S1 --> SAG1
+end
+
+%% 스타일
+classDef draft fill:#E8F4FF,stroke:#3A87F7,stroke-width:1px,color:#0A2F6B;
+classDef article fill:#E8FFE8,stroke:#3ABF7F,stroke-width:1px,color:#0A4B2F;
+classDef series fill:#F3E8FF,stroke:#9A4BFF,stroke-width:1px,color:#3B136B;
+
+class D1,D_PEND1,D_PUB1,D_SUS1,D_REM1 draft;
+class A1,A_ACT1,A_SUS1,A_REM1 article;
+class SG1,S1,SAG1,SA1,SD1 series;
+```
+
+```mermaid
+flowchart TD
+subgraph U2["사용자 2 (moon)"]
+  P2["프로필: 1개"]
+  
+  subgraph B2["블로그 2 (moon)"]
+    D2["Draft: 0개"]
+    A2["Article: 0개"]
+    S2["시리즈: 0개"]
+    SA2["시리즈-아티클 연결: 0개"]
+  end
+  
+  P2 --> B2
+  B2 --> D2
+  B2 --> A2
+  B2 --> S2
+  S2 --> SA2
+end
+
+%% 스타일
+classDef zero fill:#F5F5F5,stroke:#BFBFBF,color:#8C8C8C,stroke-dasharray: 3 2;
+class D2,A2,S2,SA2,B2,U2 zero;
+```

--- a/monolith/main-runner/src/main/resources/db/migration/dummy/README.md
+++ b/monolith/main-runner/src/main/resources/db/migration/dummy/README.md
@@ -7,12 +7,14 @@
   <th>회원 생성 초기화</th>
 </tr>
 <tr>
+</tr>
+<tr>
   <td>
-  
-  - `"auth"."user"`: 2
-  - `"profile"."profile"`: 2
-  - `"blog"."blog"`: 2
-  
+
+- `"auth"."user"`: 2
+- `"profile"."profile"`: 2
+- `"blog"."blog"`: 2
+
   </td>
 </tr>
 </table>
@@ -22,27 +24,30 @@
   <th>게시물 존재 초기화</th>
 </tr>
 <tr>
+</tr>
+<tr>
   <td>
-  
-  - `"article"."draft"`: 115
-  - `PENDING`: 52
-  - `PUBLISHED`: 53
+
+- `"article"."draft"`: 115
+- `PENDING`: 52
+- `PUBLISHED`: 53
+- `SUSPENDED`: 5
+- `REMOVED`: 5
+- `"article"."article"`: 63
+  - `ACTIVE`: 53
   - `SUSPENDED`: 5
   - `REMOVED`: 5
-  - `"article"."article"`: 63
-    - `ACTIVE`: 53
-    - `SUSPENDED`: 5
-    - `REMOVED`: 5
-  - `"series"."series"`: 53
-  - `"series"."series_article"`: 110
-    - Draft: 52
-    - Article: 58
-  
+- `"series"."series"`: 53
+- `"series"."series_article"`: 110
+  - Draft: 52
+  - Article: 58
+
   </td>
 </tr>
 </table>
 
 > 드래프트 블록은 아직 초기화하지 않았습니다.
+<br />
 
 ## Allocation
 
@@ -54,68 +59,83 @@ flowchart TD
 %% 사용자/블로그별 더미데이터 개요
 %% ─────────────────────────────
 
-subgraph U1["사용자 1 (sun)"]
-    P1[프로필: 1개]
-    
-    subgraph B1["블로그 1 (sun)"]
-        subgraph D1["Draft: 115개"]
-            D_PEND1["Pending 52"]
-            D_PUB1["Published 53"]
-            D_SUS1["Suspended 5"]
-            D_REM1["Removed 5"]
+    subgraph U1["사용자 1 (sun)"]
+        direction TB
+        P1[프로필: 1개]
+
+        subgraph B1["블로그 1 (sun)"]
+            direction LR
+
+            subgraph SG1["시리즈: 53개"]
+                S1["시리즈 1"]
+            end
+
+            subgraph R1["Resources"]
+                direction TB
+                subgraph D1["Draft: 115개"]
+                    direction TB
+                    D_PEND1["Pending 52"]
+                    D_PUB1["Published 53"]
+                    D_SUS1["Suspended 5"]
+                    D_REM1["Removed 5"]
+                end
+                subgraph SAG1["시리즈-아티클 연결: 110개"]
+                    direction TB
+                    SA1["Article 링크 58"]
+                    SD1["Draft 링크 52"]
+                end
+                subgraph A1["Article: 63개"]
+                    direction TB
+                    A_ACT1["Active 53"]
+                    A_SUS1["Suspended 5"]
+                    A_REM1["Removed 5"]
+                end
+            end
         end
-        subgraph A1["Article: 63개"]
-            A_ACT1["Active 53"]
-            A_SUS1["Suspended 5"]
-            A_REM1["Removed 5"]
-        end
-        subgraph SG1["시리즈: 53개"]
-            S1["시리즈 1"]
-        end
-        subgraph SAG1["시리즈-아티클 연결: 110개"]
-          SA1["Article 링크 58"]    
-          SD1["Draft 링크 52"]    
-        end
-        
+
+        P1 --> B1
+        B1 --> D1
+        B1 --> A1
+        B1 --> S1
+        S1 -->|has| SAG1
+        %% D1 -.- SAG1 -.- A1
+        %% D_PEND1 -.- D_PUB1 -.- D_SUS1 -.- D_REM1
+        %% A_ACT1 -.- A_SUS1 -.- A_REM1
+        SA1 -.- SD1
     end
 
-    P1 --> B1
-    B1 --> D1
-    B1 --> A1
-    B1 --> S1
-    S1 --> SAG1
-end
-
 %% 스타일
-classDef draft fill:#E8F4FF,stroke:#3A87F7,stroke-width:1px,color:#0A2F6B;
-classDef article fill:#E8FFE8,stroke:#3ABF7F,stroke-width:1px,color:#0A4B2F;
-classDef series fill:#F3E8FF,stroke:#9A4BFF,stroke-width:1px,color:#3B136B;
+    classDef draft fill:#E8F4FF,stroke:#3A87F7,stroke-width:1px,color:#0A2F6B;
+    classDef article fill:#E8FFE8,stroke:#3ABF7F,stroke-width:1px,color:#0A4B2F;
+    classDef series fill:#F3E8FF,stroke:#9A4BFF,stroke-width:1px,color:#3B136B;
+    classDef paper fill:#FFFFFF,stroke:#9A4BFF,stroke-width:1px,color:#3B136B;
 
-class D1,D_PEND1,D_PUB1,D_SUS1,D_REM1 draft;
-class A1,A_ACT1,A_SUS1,A_REM1 article;
-class SG1,S1,SAG1,SA1,SD1 series;
+    class D1,D_PEND1,D_PUB1,D_SUS1,D_REM1 draft;
+    class A1,A_ACT1,A_SUS1,A_REM1 article;
+    class SG1,S1,SAG1,SA1,SD1 series;
+    class R1 paper;
 ```
 
 ```mermaid
 flowchart TD
-subgraph U2["사용자 2 (moon)"]
-  P2["프로필: 1개"]
-  
-  subgraph B2["블로그 2 (moon)"]
-    D2["Draft: 0개"]
-    A2["Article: 0개"]
-    S2["시리즈: 0개"]
-    SA2["시리즈-아티클 연결: 0개"]
-  end
-  
-  P2 --> B2
-  B2 --> D2
-  B2 --> A2
-  B2 --> S2
-  S2 --> SA2
-end
+    subgraph U2["사용자 2 (moon)"]
+        P2["프로필: 1개"]
+
+        subgraph B2["블로그 2 (moon)"]
+            S2["시리즈: 0개"]
+            D2["Draft: 0개"]
+            A2["Article: 0개"]
+            SA2["시리즈-아티클 연결: 0개"]
+        end
+
+        P2 --> B2
+        B2 --> D2
+        B2 --> A2
+        B2 --> S2
+        S2 --> SA2
+    end
 
 %% 스타일
-classDef zero fill:#F5F5F5,stroke:#BFBFBF,color:#8C8C8C,stroke-dasharray: 3 2;
-class D2,A2,S2,SA2,B2,U2 zero;
+    classDef zero fill:#F5F5F5,stroke:#BFBFBF,color:#8C8C8C,stroke-dasharray: 3 2;
+    class D2,A2,S2,SA2,B2,U2 zero;
 ```

--- a/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
@@ -3,21 +3,26 @@
 --  Use:
 --    current_setting('dummy.USERID')::bigint
 
+-- ╭──────────────────────╮
+--     회원 및 블로그 초기화
+--    Auth, Profile Blog
+-- ╰──────────────────────╯
+
 -- USER 1
-SET dummy.USER_ID               = '33333333310000003';
-SET dummy.PROFILE_ID            = '33333333310000004';
-SET dummy.BLOG_ID               = '33333333310000005';
-SET dummy.USERNAME              = 'sun';
+SET LOCAL dummy.USER_ID               = '33333333310000003';
+SET LOCAL dummy.PROFILE_ID            = '33333333310000004';
+SET LOCAL dummy.BLOG_ID               = '33333333310000005';
+SET LOCAL dummy.USERNAME              = 'sun';
 
 -- USER 2
-SET dummy.USER_ID2              = '33333333320000006';
-SET dummy.PROFILE_ID2           = '33333333320000007';
-SET dummy.BLOG_ID2              = '33333333320000008';
-SET dummy.USERNAME2             = 'moon';
+SET LOCAL dummy.USER_ID2              = '33333333320000006';
+SET LOCAL dummy.PROFILE_ID2           = '33333333320000007';
+SET LOCAL dummy.BLOG_ID2              = '33333333320000008';
+SET LOCAL dummy.USERNAME2             = 'moon';
 
 -- 비밀번호
-SET dummy.USER_RAW_PASSWORD     = 'Blolet1225!';
-SET dummy.USER_ENCODED_PASSWORD =
+SET LOCAL dummy.USER_RAW_PASSWORD     = 'Blolet1225!';
+SET LOCAL dummy.USER_ENCODED_PASSWORD =
     '$argon2id$v=19$m=32768,t=4,p=1$y2CjGj9VT7FUmmRu1brflw$h9MfPg2iT2Doh9w/J1ORBpmOE0/ZWVa2q4kMIPlmqc8';
 
 INSERT INTO "auth"."user" (
@@ -104,6 +109,245 @@ INSERT INTO "blog"."blog" (
     '침착 너구리의 블로그',
     current_setting('dummy.USERNAME2')::varchar
 );
+
+-- ╭──────────────────────────────╮
+--    Draft, Article, 시리즈 초기화
+-- ╰──────────────────────────────╯
+
+SET LOCAL dummy.DRAFT_ID_BASE           = '3333333333';
+SET LOCAL dummy.DRAFT_ID_DYNAMIC_SIZE   = 7;
+
+SET LOCAL dummy.ARTICLE_ID_BASE         = '3333333334';
+SET LOCAL dummy.ARTICLE_ID_DYNAMIC_SIZE = 7;
+
+-- 상태 상수 계산 → 세션 변수(dummy.~)에 LOCAL로 저장
+WITH v(name, val) AS (
+    VALUES
+    -- draft status
+    ('dummy.DRAFT_REMOVED',     (X'00000000'::bit(32)::int)::text),
+    ('dummy.DRAFT_PENDING',     (X'6C000100'::bit(32)::int)::text),
+    ('dummy.DRAFT_PUBLISHED',   (X'6C000200'::bit(32)::int)::text),
+    ('dummy.DRAFT_UPDATED',     (X'6C000210'::bit(32)::int)::text),
+    ('dummy.DRAFT_SUSPENDED',   (X'28000400'::bit(32)::int)::text),
+
+    -- draft block status
+    ('dummy.DRAFT_BLOCK_REMOVED',   (X'00000000'::bit(32)::int)::text),
+    ('dummy.DRAFT_BLOCK_PENDING',   (X'6C000100'::bit(32)::int)::text),
+    ('dummy.DRAFT_BLOCK_PUBLISHED', (X'6C000200'::bit(32)::int)::text),
+    ('dummy.DRAFT_BLOCK_UPDATED',   (X'6C000210'::bit(32)::int)::text),
+    ('dummy.DRAFT_BLOCK_SUSPENDED', (X'28000400'::bit(32)::int)::text),
+
+    -- article status
+    ('dummy.ARTICLE_REMOVED',   (X'08000000'::bit(32)::int)::text),
+    ('dummy.ARTICLE_PENDING',   (X'6C000100'::bit(32)::int)::text),
+    ('dummy.ARTICLE_ACTIVE',    (X'6C000200'::bit(32)::int)::text),
+    ('dummy.ARTICLE_SUSPENDED', (X'28000400'::bit(32)::int)::text)
+)
+SELECT set_config(name, val, true)  -- true = LOCAL
+FROM v;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Draft(115) 생성: 1..58=PUBLISHED, 59..110=PENDING, 111..115=REMOVED
+--  - id/경로는 연속 번호 사용
+-- ─────────────────────────────────────────────────────────────────────────────
+
+INSERT INTO "article"."draft" (
+    id,
+    blog_id,
+    title,
+    "path",
+    status
+)
+    SELECT
+        (current_setting('dummy.DRAFT_ID_BASE')::text
+            || lpad(gs::text, current_setting('dummy.DRAFT_ID_DYNAMIC_SIZE')::int, '0'))::bigint AS id,
+            current_setting('dummy.BLOG_ID')::bigint AS blog_id,
+            'title_' || gs AS title,
+        'post-' || gs AS "path",
+        CASE
+            WHEN gs BETWEEN 1 AND 58  THEN current_setting('dummy.DRAFT_PUBLISHED')::int    -- PUBLISHED
+            WHEN gs BETWEEN 59 AND 110 THEN current_setting('dummy.DRAFT_PENDING')::int     -- PENDING
+            ELSE current_setting('dummy.DRAFT_REMOVED')::int                                -- REMOVED
+            END AS status
+    FROM generate_series(1, 115) gs;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Article(63) 생성 및 Draft.article_id 연결
+--  - PUBLISHED Draft 중 id 오름차순 53개 → Article ACTIVE
+--  - 나머지 PUBLISHED 5개 → Article SUSPENDED
+--  - REMOVED Draft 5개 → Article REMOVED
+--  - Article ID는 dummy.ARTICLE_ID_BASE + 연속번호(패딩)
+--  - Article.path/title 은 매핑된 Draft와 동일
+-- ─────────────────────────────────────────────────────────────────────────────
+
+WITH
+    pub AS (
+        -- PUBLISHED
+        SELECT
+            d.*, ROW_NUMBER() OVER (ORDER BY d.id) AS rn
+        FROM "article"."draft" d
+        WHERE
+            d.blog_id = current_setting('dummy.BLOG_ID')::bigint
+            AND d.status = current_setting('dummy.DRAFT_PUBLISHED')::int
+    ),
+    rm AS (
+        -- REMOVED
+        SELECT
+            d.*
+        FROM "article"."draft" d
+        WHERE
+            d.blog_id = current_setting('dummy.BLOG_ID')::bigint
+            AND d.status = current_setting('dummy.DRAFT_REMOVED')::int
+        ORDER BY d.id
+    ),
+    to_insert AS (
+        -- ACTIVE
+        SELECT
+            p.blog_id,
+            p.title,
+            p."path",
+            current_setting('dummy.ARTICLE_ACTIVE')::int AS article_status,
+            p.rn AS ord
+        FROM pub p WHERE p.rn <= 53
+        UNION ALL
+            -- SUSPENDED
+            SELECT
+                p.blog_id,
+                p.title,
+                p."path",
+                current_setting('dummy.ARTICLE_SUSPENDED')::int AS article_status,
+                p.rn
+            FROM pub p WHERE p.rn > 53
+        UNION ALL
+            -- REMOVED
+            SELECT
+                r.blog_id,
+                r.title,
+                r."path",
+                current_setting('dummy.ARTICLE_REMOVED')::int AS article_status,
+                r.id::bigint
+            FROM rm r
+    ),
+    ins AS (
+        INSERT INTO "article"."article" (
+            id,
+            blog_id,
+            title,
+            "path",
+            status,
+            total_views,
+            total_likes,
+            total_shares
+        )
+        SELECT
+            (
+                current_setting('dummy.ARTICLE_ID_BASE')::text
+                || LPAD(
+                        ROW_NUMBER() OVER (ORDER BY ord)::text,
+                        current_setting('dummy.ARTICLE_ID_DYNAMIC_SIZE')::int,
+                        '0'
+                )
+            )::bigint AS id,
+            blog_id,
+            title,
+            "path",
+            article_status,
+            0,
+            0,
+            0
+        FROM to_insert
+        RETURNING
+            id,
+            blog_id,
+            "path"
+    )
+
+UPDATE "article"."draft" d
+SET
+    article_id = i.id
+FROM ins i
+WHERE d.blog_id = i.blog_id
+    AND d."path" = i."path";
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Series(53) 생성: title 'Series 1'..'Series 53'
+-- ─────────────────────────────────────────────────────────────────────────────
+INSERT INTO "series"."series" (
+    blog_id,
+    title,
+    "description",
+    display_order
+)
+    SELECT
+        current_setting('dummy.BLOG_ID')::bigint,
+        'Series ' || gs,
+        'Demo series #' || gs,
+        gs
+    FROM generate_series(1, 53) gs;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- SeriesArticle: 첫 번째 시리즈에만 묶기
+--  - PENDING Draft 52개 (draft_id 세팅)
+--  - ACTIVE 53개 + SUSPENDED 5개 (article_id 세팅)
+-- ─────────────────────────────────────────────────────────────────────────────
+WITH
+    first_series AS (
+        SELECT
+            MIN(s.id) AS sid
+        FROM "series"."series" s
+        WHERE s.blog_id = current_setting('dummy.BLOG_ID')::bigint
+    ),
+    pending_drafts AS (
+        SELECT
+            d.id,
+            ROW_NUMBER() OVER (ORDER BY d.id) AS rn
+        FROM "article"."draft" d
+        WHERE
+            d.blog_id = current_setting('dummy.BLOG_ID')::bigint
+            -- PENDING
+            AND d.status = current_setting('dummy.DRAFT_PENDING')::int
+    ),
+    active_susp_articles AS (
+        SELECT
+            a.id, ROW_NUMBER() OVER (ORDER BY a.id) AS rn
+        FROM "article"."article" a
+        WHERE
+            a.blog_id = current_setting('dummy.BLOG_ID')::bigint
+            -- ACTIVE, SUSPENDED
+            AND a.status IN (
+                current_setting('dummy.ARTICLE_ACTIVE')::int,
+                current_setting('dummy.ARTICLE_SUSPENDED')::int
+            )
+    ),
+    ins_pending AS (
+        -- PENDING drafts 52개
+        INSERT INTO "series"."series_article"(
+            series_id,
+            draft_id,
+            display_order
+        )
+        SELECT
+            f.sid,
+            p.id,
+            p.rn
+        FROM first_series f
+            JOIN (SELECT * FROM pending_drafts ORDER BY rn LIMIT 52) p
+                ON TRUE
+            RETURNING 1
+    )
+-- ACTIVE 53개 + SUSPENDED 5개 = 58개
+INSERT INTO "series"."series_article" (
+    series_id,
+    article_id,
+    display_order
+)
+SELECT
+    f.sid,
+    a.id,
+    a.rn
+FROM first_series f
+    JOIN active_susp_articles a
+        ON TRUE;
 
 -- statistics
 --  "auth"."user":          2 rows

--- a/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
@@ -165,7 +165,8 @@ INSERT INTO "article"."draft" (
             'title_' || gs AS title,
         'post-' || gs AS "path",
         CASE
-            WHEN gs BETWEEN 1 AND 58  THEN current_setting('dummy.DRAFT_PUBLISHED')::int    -- PUBLISHED
+            WHEN gs BETWEEN 1 AND 53  THEN current_setting('dummy.DRAFT_PUBLISHED')::int    -- PUBLISHED
+            WHEN gs BETWEEN 54 AND 58  THEN current_setting('dummy.DRAFT_SUSPENDED')::int   -- SUSPENDED
             WHEN gs BETWEEN 59 AND 110 THEN current_setting('dummy.DRAFT_PENDING')::int     -- PENDING
             ELSE current_setting('dummy.DRAFT_REMOVED')::int                                -- REMOVED
             END AS status


### PR DESCRIPTION
## Issues

- Resolves #357 
  - Resolves #362

## Description

- Flyway 초기화 및 개발용 더미데이터 시드 추가
  - **Repeatable** 마이그레이션 `R__init_dummies.sql` (scope: **monolith**)에 더미 데이터 추가  
    (Profile: `local`, `dev`)
  - 세션 변수(`dummy.~`) 기반으로 **USER/BLOG/DRAFT/ARTICLE/SERIES** 초깃값 및 ID 베이스 설정
  - Draft/Article **상태 비트**(카테고리/인스턴스) 계산식 추가 및 상수화
  - `Series` 53개 생성 및 **첫 번째 시리즈에만** Draft/Article을 묶는 `SeriesArticle` 시드 로직 구성
  - CTE(common table expression) 활용 초기화
- Rel: #357 

<br />

## Review Points

- **Repeatable vs Versioned**
  - 로컬/개발 전용 데이터이므로 `R__init_dummies.sql` 선택이 적절한지, 운영 배포 경로에 포함되지 않도록 **프로파일/스코프(monolith)** 제한이 충분한지
- **트랜잭션 & 세션 변수**
  - `SET LOCAL dummy.*` 가 Flyway의 트랜잭션 경계 안에서 안정적으로 적용되는지 (PostgreSQL은 기본 트랜잭션 지원)
- **ID 충돌 방지**
  - `DRAFT_ID_BASE / ARTICLE_ID_BASE` 및 `*_DYNAMIC_SIZE` 조합이 기존/향후 시드와 **중복 없이** 동작하는지
- **상태 비트 일관성**
  - Hex/bit 연산으로 계산된 Draft/Article 상태 값이 도메인 `StatusParameters`/`ErrorCode` 설계와 일치하는지
- **시리즈 연결 로직**
  - `first_series` CTE 범위 수정 후, **단일 시리즈에만** 묶이는 의도가 정확히 반영되는지 (PENDING Draft 52개, Article(Active 53 + Suspended 5))
- **성능/결정성**
  - `generate_series` 기반 시드가 환경마다 결정적으로 동일 결과를 보장하는지, 정렬/최소값(`MIN(id)`) 의존이 안전한지
- **보안**
  - 초기 계정 암호(해시) 등 민감 값이 레포지토리에 남지 않도록 필요 시 별도 시크릿/프로파일로 분리되어 있는지

<br />

## How Has This Been Tested?

- **실행하여 육안으로 확인하였습니다.**
- **로컬 개발 DB** 에서 Flyway `migrate` 실행 후, 주요 테이블 건수/분포를 쿼리하여 확인
  - `"auth"."user"`: 2
  - `"profile"."profile"`: 2
  - `"blog"."blog"`: 2
  - `"article"."draft"`: 115 (PENDING 52 / PUBLISHED 53 / SUSPENDED 5 / REMOVED 5)
  - `"article"."article"`: 63 (ACTIVE 53 / SUSPENDED 5 / REMOVED 5)
  - `"series"."series"`: 53
  - `"series"."series_article"`: 110 (Draft 52 / Article 58)
- **CTE 검증**
  - (접근 범위를 수정한 이후로) `SeriesArticle` 레코드가 의도대로 생성되는지 확인
- **AI 제안**
  - ephemeral DB 컨테이너(예: Testcontainers)로 `flyway clean migrate` 수행 후 **검증 쿼리 스냅샷 테스트** 추가
  - 주요 상태 비트 계산식에 대한 **회귀 테스트**(예: 예상 int 값 매칭)
  - <del>FK</del>/유니크 제약 위반 여부를 확인하는 **스키마 무결성 테스트**(예: INSERT 실패 케이스 포함)
  - `R__init_dummies.sql` <del>이 **monolith 프로파일에서만**</del> **`local` 및 `dev` 프로파일에서만** 실행되는지 환경 분기 테스트

<br />

## Additional Notes

- 비교 링크: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/flyway
- 이 더미데이터는 **개발/데모 용도**입니다. 운영 환경에는 포함되지 않도록 프로파일/배포 파이프라인에서 반드시 차단해 주세요.
- <del>재시드가 필요하면 로컬에서 `flyway clean migrate`(주의!) 또는 해당 Repeatable 파일 변경으로 재실행을 유도할 수 있습니다.</del>  
  모든 데이터베이스를 날리고 다시 실행하는 것이 편리합니다.  
  ```shell
  ./monolith-compose down -v
  ./monolith-compose up -d
  ```

# README.md 참고

## Dummy Data

### Count

<table>
<tr>
  <th>회원 생성 초기화</th>
</tr>
<tr>
</tr>
<tr>
  <td>

- `"auth"."user"`: 2
- `"profile"."profile"`: 2
- `"blog"."blog"`: 2

  </td>
</tr>
</table>

<table>
<tr>
  <th>게시물 존재 초기화</th>
</tr>
<tr>
</tr>
<tr>
  <td>

- `"article"."draft"`: 115
- `PENDING`: 52
- `PUBLISHED`: 53
- `SUSPENDED`: 5
- `REMOVED`: 5
- `"article"."article"`: 63
  - `ACTIVE`: 53
  - `SUSPENDED`: 5
  - `REMOVED`: 5
- `"series"."series"`: 53
- `"series"."series_article"`: 110
  - Draft: 52
  - Article: 58

  </td>
</tr>
</table>

> 드래프트 블록은 아직 초기화하지 않았습니다.
<br />

### Allocation

사용자 1의 블로그에 모든 아티클, 드래프트, 시리즈가 존재합니다.

```mermaid
flowchart TD
%% ─────────────────────────────
%% 사용자/블로그별 더미데이터 개요
%% ─────────────────────────────

    subgraph U1["사용자 1 (sun)"]
        direction TB
        P1[프로필: 1개]

        subgraph B1["블로그 1 (sun)"]
            direction LR

            subgraph SG1["시리즈: 53개"]
                S1["시리즈 1"]
            end

            subgraph R1["Resources"]
                direction TB
                subgraph D1["Draft: 115개"]
                    direction TB
                    D_PEND1["Pending 52"]
                    D_PUB1["Published 53"]
                    D_SUS1["Suspended 5"]
                    D_REM1["Removed 5"]
                end
                subgraph SAG1["시리즈-아티클 연결: 110개"]
                    direction TB
                    SA1["Article 링크 58"]
                    SD1["Draft 링크 52"]
                end
                subgraph A1["Article: 63개"]
                    direction TB
                    A_ACT1["Active 53"]
                    A_SUS1["Suspended 5"]
                    A_REM1["Removed 5"]
                end
            end
        end

        P1 --> B1
        B1 --> D1
        B1 --> A1
        B1 --> S1
        S1 -->|has| SAG1
        %% D1 -.- SAG1 -.- A1
        %% D_PEND1 -.- D_PUB1 -.- D_SUS1 -.- D_REM1
        %% A_ACT1 -.- A_SUS1 -.- A_REM1
        SA1 -.- SD1
    end

%% 스타일
    classDef draft fill:#E8F4FF,stroke:#3A87F7,stroke-width:1px,color:#0A2F6B;
    classDef article fill:#E8FFE8,stroke:#3ABF7F,stroke-width:1px,color:#0A4B2F;
    classDef series fill:#F3E8FF,stroke:#9A4BFF,stroke-width:1px,color:#3B136B;
    classDef paper fill:#FFFFFF,stroke:#9A4BFF,stroke-width:1px,color:#3B136B;

    class D1,D_PEND1,D_PUB1,D_SUS1,D_REM1 draft;
    class A1,A_ACT1,A_SUS1,A_REM1 article;
    class SG1,S1,SAG1,SA1,SD1 series;
    class R1 paper;
```

```mermaid
flowchart TD
    subgraph U2["사용자 2 (moon)"]
        P2["프로필: 1개"]

        subgraph B2["블로그 2 (moon)"]
            S2["시리즈: 0개"]
            D2["Draft: 0개"]
            A2["Article: 0개"]
            SA2["시리즈-아티클 연결: 0개"]
        end

        P2 --> B2
        B2 --> D2
        B2 --> A2
        B2 --> S2
        S2 --> SA2
    end

%% 스타일
    classDef zero fill:#F5F5F5,stroke:#BFBFBF,color:#8C8C8C,stroke-dasharray: 3 2;
    class D2,A2,S2,SA2,B2,U2 zero;
```