### PR TITLE
Series > Application, RDB: 시리즈 상세 조회 시, 어댑터에서 아티클 목록을 포함하여 반환합니다. 또한 배너 이미지는 이제 URL로 관리합니다.

### DIFF
--- a/services/series/api/domain/src/main/java/nettee/series/domain/Series.java
+++ b/services/series/api/domain/src/main/java/nettee/series/domain/Series.java
@@ -24,7 +24,7 @@ public class Series {
     
     private String description;
     
-    private String banner;
+    private String bannerUrl;
     
     private Integer displayOrder;
     
@@ -39,13 +39,13 @@ public class Series {
             builderMethodName = "prepareUpdate",
             buildMethodName = "update"
     )
-    public void update(String title, Integer displayOrder, String description, String banner) {
+    public void update(String title, Integer displayOrder, String description, String bannerUrl) {
         Objects.requireNonNull(title, "Title cannot be null");
         Objects.requireNonNull(displayOrder, "DisplayOrder cannot be null");
         
         this.title = title;
         this.description = description;
-        this.banner = banner;
+        this.bannerUrl = bannerUrl;
         this.displayOrder = displayOrder;
         this.updatedAt = Instant.now();
     }

--- a/services/series/api/readmodel/src/main/java/nettee/series/article/readmodel/SeriesArticleQueryModels.java
+++ b/services/series/api/readmodel/src/main/java/nettee/series/article/readmodel/SeriesArticleQueryModels.java
@@ -13,7 +13,7 @@ public final class SeriesArticleQueryModels {
             String seriesId,
             String articleId,
             String draftId,
-            String articleTitle,
+            String title,
             Integer displayOrder,
             Instant createdAt,
             Instant updatedAt

--- a/services/series/api/readmodel/src/main/java/nettee/series/article/readmodel/SeriesArticleQueryModels.java
+++ b/services/series/api/readmodel/src/main/java/nettee/series/article/readmodel/SeriesArticleQueryModels.java
@@ -1,5 +1,6 @@
 package nettee.series.article.readmodel;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.Instant;
@@ -13,6 +14,10 @@ public final class SeriesArticleQueryModels {
             String seriesId,
             String articleId,
             String draftId,
+            @Schema(
+                    description = "최근 제목 (아티클이 있다면 아티클의 제목, 아니라면 드래프트의 제목)",
+                    example = "테토남은 예시 같은 거 디테일하게 쓰지 않는다."
+            )
             String title,
             Integer displayOrder,
             Instant createdAt,

--- a/services/series/api/readmodel/src/main/java/nettee/series/readmodel/SeriesQueryModels.java
+++ b/services/series/api/readmodel/src/main/java/nettee/series/readmodel/SeriesQueryModels.java
@@ -21,18 +21,6 @@ public final class SeriesQueryModels {
             Instant createdAt,
             Instant updatedAt
     ) {
-        public SeriesDetail addSummaryList(List<SeriesArticleSummary> summaryList) {
-            return new SeriesDetail(
-                    this.id,
-                    this.blogId,
-                    this.title,
-                    this.description,
-                    this.banner,
-                    summaryList,
-                    this.createdAt,
-                    this.updatedAt
-            );
-        }
     }
     
     @Builder

--- a/services/series/api/readmodel/src/main/java/nettee/series/readmodel/SeriesQueryModels.java
+++ b/services/series/api/readmodel/src/main/java/nettee/series/readmodel/SeriesQueryModels.java
@@ -1,5 +1,6 @@
 package nettee.series.readmodel;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import nettee.series.article.readmodel.SeriesArticleQueryModels.SeriesArticleSummary;
 
@@ -16,7 +17,11 @@ public final class SeriesQueryModels {
             String blogId,
             String title,
             String description,
-            String banner,
+            @Schema(
+                    description = "시리즈 배너 이미지 경로",
+                    example = "https://assets.blolet.com/images/series/01234567-89ab-cdef-0123-456789abcdef"
+            )
+            String bannerUrl,
             List<SeriesArticleSummary> seriesArticleSummaryList,
             Instant createdAt,
             Instant updatedAt

--- a/services/series/api/readmodel/src/main/java/nettee/series/readmodel/SeriesQueryModels.java
+++ b/services/series/api/readmodel/src/main/java/nettee/series/readmodel/SeriesQueryModels.java
@@ -22,7 +22,7 @@ public final class SeriesQueryModels {
                     example = "https://assets.blolet.com/images/series/01234567-89ab-cdef-0123-456789abcdef"
             )
             String bannerUrl,
-            List<SeriesArticleSummary> seriesArticleSummaryList,
+            List<SeriesArticleSummary> articles,
             Instant createdAt,
             Instant updatedAt
     ) {

--- a/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
+++ b/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
@@ -3,7 +3,6 @@ package nettee.series.application.services;
 import lombok.RequiredArgsConstructor;
 import nettee.series.application.port.SeriesQueryRepositoryPort;
 import nettee.series.application.usecase.SeriesReadUseCase;
-import nettee.series.article.application.usecase.SeriesArticleReadUseCase;
 import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
 import nettee.series.readmodel.SeriesQueryModels.SeriesSummary;
 import org.springframework.stereotype.Service;
@@ -17,23 +16,13 @@ import static nettee.series.exception.SeriesErrorCode.SERIES_NOT_FOUND;
 public class SeriesQueryService implements SeriesReadUseCase {
     
     private final SeriesQueryRepositoryPort queryRepositoryPort;
-    private final SeriesArticleReadUseCase seriesArticleReadUseCase;
     
     @Override
     public SeriesDetail getSeries(String seriesId) {
         assert seriesId != null;
-        
-        var series = queryRepositoryPort.findBySeriesId(seriesId)
-                .orElseThrow(SERIES_NOT_FOUND::exception);
-        
-        // 시리즈 게시물 조회
-        var seriesArticleSummary = seriesArticleReadUseCase.getSeriesArticleList(seriesId);
 
-        if(seriesArticleSummary != null && !seriesArticleSummary.isEmpty()) {
-           return series.addSummaryList(seriesArticleSummary);
-        }
-        
-        return series;
+        return queryRepositoryPort.findBySeriesId(seriesId)
+                .orElseThrow(SERIES_NOT_FOUND::exception);
     }
     
     @Override

--- a/services/series/driven/rdb/build.gradle.kts
+++ b/services/series/driven/rdb/build.gradle.kts
@@ -1,11 +1,17 @@
 val seriesApi: String by project
 val seriesApplication: String by project
 
+// FIXME 모듈 통합 전이므로 코드 확인을 위해 임시로 사용합니다:
+val articleRdbAdapter: String by project
+val draftRdbAdapter: String by project
+
 dependencies {
     val bom = dependencyManagement.importedProperties
 
     api(project(seriesApi))
     api(project(seriesApplication))
+    api(project(articleRdbAdapter))
+    api(project(draftRdbAdapter))
     api(project(":jpa-core"))
 
     // querydsl

--- a/services/series/driven/rdb/src/main/java/nettee/series/article/driven/rdb/entity/SeriesArticleEntity.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/article/driven/rdb/entity/SeriesArticleEntity.java
@@ -10,7 +10,7 @@ import nettee.jpa.support.SnowflakeBaseTimeEntity;
 import java.util.Objects;
 
 @Entity
-@Table(name = "series_article", schema = "series")
+@Table(name = "series_article", schema = "article")
 @SuperBuilder
 @NoArgsConstructor
 public class SeriesArticleEntity extends SnowflakeBaseTimeEntity {
@@ -24,7 +24,7 @@ public class SeriesArticleEntity extends SnowflakeBaseTimeEntity {
     public Integer displayOrder;
     
     @Builder(
-            builderClassName = "updateSeriesArticleEntityBuilder",
+            builderClassName = "UpdateSeriesArticleEntityBuilder",
             builderMethodName = "prepareUpdate",
             buildMethodName = "updateArticleId"
     )

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/entity/SeriesEntity.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/entity/SeriesEntity.java
@@ -11,7 +11,7 @@ import nettee.jpa.support.LongBaseTimeEntity;
 import java.util.Objects;
 
 @Entity
-@Table(name = "series", schema = "series")
+@Table(name = "series", schema = "article")
 @SuperBuilder
 @NoArgsConstructor
 public class SeriesEntity extends LongBaseTimeEntity {

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/entity/SeriesEntity.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/entity/SeriesEntity.java
@@ -23,7 +23,7 @@ public class SeriesEntity extends LongBaseTimeEntity {
     
     public String description;
     
-    public byte[] banner;
+    public String bannerUrl;
     
     public Integer displayOrder;
     
@@ -32,13 +32,13 @@ public class SeriesEntity extends LongBaseTimeEntity {
             builderMethodName = "prepareUpdate",
             buildMethodName = "update"
     )
-    public void update(String title, String description, byte[] banner, Integer displayOrder) {
+    public void update(String title, String description, String banner, Integer displayOrder) {
         Objects.requireNonNull(title, "Title cannot be null");
         Objects.requireNonNull(displayOrder, "DisplayOrder cannot be null");
         
         this.title = title;
         this.description = description;
-        this.banner = banner;
+        this.bannerUrl = banner;
         this.displayOrder = displayOrder;
     }
 }

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesCommandAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesCommandAdapter.java
@@ -35,7 +35,7 @@ public class SeriesCommandAdapter implements SeriesCommandRepositoryPort {
         existsSeries.prepareUpdate()
                 .title(series.getTitle())
                 .description(series.getDescription())
-                .banner(seriesEntityMapper.base64ToBytes(series.getBanner()))
+                .banner(series.getBannerUrl())
                 .displayOrder(series.getDisplayOrder())
                 .update();
         

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
@@ -19,6 +19,7 @@ import static nettee.article.driven.rdb.entity.QArticleEntity.articleEntity;
 import static nettee.draft.driven.rdb.entity.QDraftEntity.draftEntity;
 import static nettee.series.article.driven.rdb.entity.QSeriesArticleEntity.seriesArticleEntity;
 import static nettee.series.driven.rdb.entity.QSeriesEntity.seriesEntity;
+import static nettee.series.exception.SeriesErrorCode.SERIES_NOT_FOUND;
 
 @Repository
 public class SeriesQueryAdapter extends QuerydslRepositorySupport implements SeriesQueryRepositoryPort {
@@ -56,7 +57,7 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
                 .where(seriesEntity.id.eq(longSeriesId))
                 .fetchOne();
 
-        if (seriesDetail == null) return Optional.empty();
+        if (seriesDetail == null) throw SERIES_NOT_FOUND.exception();
 
         List<SeriesArticleSummaryProjection> articles = getQuerydsl().createQuery()
                 .select(Projections.constructor(

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
@@ -1,37 +1,79 @@
 package nettee.series.driven.rdb.persistence;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import nettee.series.application.port.SeriesQueryRepositoryPort;
 import nettee.series.driven.rdb.entity.SeriesEntity;
 import nettee.series.driven.rdb.persistence.mapper.SeriesEntityMapper;
-import nettee.series.readmodel.SeriesQueryModels.SeriesSummary;
+import nettee.series.driven.rdb.persistence.projection.SeriesProjections.SeriesArticleSummaryProjection;
+import nettee.series.driven.rdb.persistence.projection.SeriesProjections.SeriesDetailProjection;
 import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
+import nettee.series.readmodel.SeriesQueryModels.SeriesSummary;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+import static nettee.article.driven.rdb.entity.QArticleEntity.articleEntity;
+import static nettee.draft.driven.rdb.entity.QDraftEntity.draftEntity;
+import static nettee.series.article.driven.rdb.entity.QSeriesArticleEntity.seriesArticleEntity;
 import static nettee.series.driven.rdb.entity.QSeriesEntity.seriesEntity;
 
 @Repository
 public class SeriesQueryAdapter extends QuerydslRepositorySupport implements SeriesQueryRepositoryPort {
     
-    private final SeriesEntityMapper seriesEntityMapper;
+    private final SeriesEntityMapper mapper;
     
     public SeriesQueryAdapter(final SeriesEntityMapper seriesEntityMapper) {
         super(SeriesEntity.class);
-        this.seriesEntityMapper = seriesEntityMapper;
+        this.mapper = seriesEntityMapper;
     }
     
     @Override
     public Optional<SeriesDetail> findBySeriesId(String seriesId) {
-        return seriesEntityMapper.toOptionalSeriesDetail(
-                getQuerydsl().createQuery()
-                        .select(seriesEntity)
-                        .from(seriesEntity)
-                        .where(seriesEntity.id.eq(Long.valueOf(seriesId)))
-                        .fetchOne()
+        Long longSeriesId = Long.parseLong(seriesId);
+
+        SeriesDetailProjection seriesDetail = getQuerydsl().createQuery()
+                .select(Projections.constructor(
+                        SeriesDetailProjection.class,
+                        seriesEntity.id,
+                        seriesEntity.blogId,
+                        seriesEntity.title,
+                        seriesEntity.description,
+                        seriesEntity.bannerUrl,
+                        seriesEntity.displayOrder,
+                        seriesEntity.createdAt,
+                        seriesEntity.updatedAt
+                ))
+                .from(seriesEntity)
+                .where(seriesEntity.id.eq(longSeriesId))
+                .fetchOne();
+
+        List<SeriesArticleSummaryProjection> articles = getQuerydsl().createQuery()
+                .select(Projections.constructor(
+                        SeriesArticleSummaryProjection.class,
+//                        seriesArticleEntity.seriesId,
+                        seriesArticleEntity.articleId,
+                        seriesArticleEntity.draftId,
+                        Expressions.stringTemplate(
+                                "coalesce({0}, {1})",
+                                articleEntity.title,
+                                draftEntity.title
+                        ),
+                        seriesArticleEntity.displayOrder,
+                        seriesArticleEntity.createdAt,
+                        seriesArticleEntity.updatedAt
+                ))
+                .from(seriesArticleEntity)
+                .leftJoin(articleEntity).on(seriesArticleEntity.articleId.eq(articleEntity.id))
+                .leftJoin(draftEntity).on(seriesArticleEntity.draftId.eq(draftEntity.id))
+                .where(seriesArticleEntity.seriesId.eq(longSeriesId))
+                .orderBy(seriesArticleEntity.displayOrder.asc())
+                .fetch();
+
+        return Optional.ofNullable(
+                mapper.toDetail(seriesDetail, articles)
         );
     }
     

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
@@ -29,7 +29,13 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
         super(SeriesEntity.class);
         this.mapper = seriesEntityMapper;
     }
-    
+
+    /**
+     * 트래픽 절감, 안정적인 성능, 높은 유지보수성을 위하여 '싱글쿼리(단일 쿼리)' 대신 '스플릿 쿼리(분할 쿼리)'를 사용합니다.
+     *
+     * @param seriesId
+     * @return
+     */
     @Override
     public Optional<SeriesDetail> findBySeriesId(String seriesId) {
         Long longSeriesId = Long.parseLong(seriesId);
@@ -49,6 +55,8 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
                 .from(seriesEntity)
                 .where(seriesEntity.id.eq(longSeriesId))
                 .fetchOne();
+
+        if (seriesDetail == null) return Optional.empty();
 
         List<SeriesArticleSummaryProjection> articles = getQuerydsl().createQuery()
                 .select(Projections.constructor(

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/mapper/SeriesEntityMapper.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/mapper/SeriesEntityMapper.java
@@ -1,21 +1,31 @@
 package nettee.series.driven.rdb.persistence.mapper;
 
 
+import nettee.series.article.readmodel.SeriesArticleQueryModels.SeriesArticleSummary;
 import nettee.series.domain.Series;
 import nettee.series.driven.rdb.entity.SeriesEntity;
+import nettee.series.driven.rdb.persistence.projection.SeriesProjections.SeriesArticleSummaryProjection;
+import nettee.series.driven.rdb.persistence.projection.SeriesProjections.SeriesDetailProjection;
 import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-import java.util.Optional;
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface SeriesEntityMapper {
     
     Series toDomain(SeriesEntity seriesEntity);
-    SeriesDetail toSeriesDetail(SeriesEntity seriesEntity);
     SeriesEntity toEntity(Series series);
-    
-    default Optional<SeriesDetail> toOptionalSeriesDetail(SeriesEntity seriesEntity) {
-        return Optional.ofNullable(toSeriesDetail(seriesEntity));
-    }
+
+    SeriesDetail toDetail(SeriesDetailProjection projection, List<SeriesArticleSummaryProjection> articles);
+
+    /**
+     * NOTE will be used by `SeriesDetail toSeriesDetail(...)` or other functions.
+     *
+     * @param projection 시리즈 아티클 요약(summary) 조회 아이템
+     * @return read model
+     */
+    @Mapping(target = "title", source = "currentTitle")
+    SeriesArticleSummary toSeriesArticleSummary(SeriesArticleSummaryProjection projection);
 }

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/mapper/SeriesEntityMapper.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/mapper/SeriesEntityMapper.java
@@ -5,37 +5,17 @@ import nettee.series.domain.Series;
 import nettee.series.driven.rdb.entity.SeriesEntity;
 import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 
-import java.util.Base64;
 import java.util.Optional;
 
 @Mapper(componentModel = "spring")
 public interface SeriesEntityMapper {
     
-    @Mapping(target = "banner", source = "banner", qualifiedByName = "bytesToBase64")
     Series toDomain(SeriesEntity seriesEntity);
-    
-    @Mapping(target = "banner", source = "banner", qualifiedByName = "bytesToBase64")
     SeriesDetail toSeriesDetail(SeriesEntity seriesEntity);
-    
-    @Mapping(target = "banner", source = "banner", qualifiedByName = "base64ToBytes")
     SeriesEntity toEntity(Series series);
     
     default Optional<SeriesDetail> toOptionalSeriesDetail(SeriesEntity seriesEntity) {
         return Optional.ofNullable(toSeriesDetail(seriesEntity));
-    }
-    
-    @Named("bytesToBase64")
-    default String bytesToBase64(byte[] bytes) {
-        return bytes != null ?
-                Base64.getEncoder().withoutPadding().encodeToString(bytes) :
-                null;
-    }
-    
-    @Named("base64ToBytes")
-    default byte[] base64ToBytes(String encoded) {
-        return encoded != null ? Base64.getDecoder().decode(encoded) : null;
     }
 }

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/projection/SeriesProjections.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/projection/SeriesProjections.java
@@ -1,0 +1,28 @@
+package nettee.series.driven.rdb.persistence.projection;
+
+import java.time.Instant;
+
+public final class SeriesProjections {
+    private SeriesProjections() {}
+
+    public record SeriesDetailProjection(
+            Long id,
+            Long blogId,
+            String title,
+            String description,
+            String bannerUrl,
+            Integer displayOrder,
+            Instant createdAt,
+            Instant updatedAt
+    ) {}
+
+    public record SeriesArticleSummaryProjection(
+            // Long seriesId,
+            Long articleId,
+            Long draftId,
+            String currentTitle,
+            Integer displayOrder,
+            Instant createdAt,
+            Instant updatedAt
+    ) {}
+}


### PR DESCRIPTION
<br /><br />

<table border="3" align="center">
<tr height="45">
  <td width="45" align="center">🤖</td>
  <td align="center"><strong>이 문서는 인공지능으로 작성하였습니다.</strong></td>
</tr>
</table>

<br />

## Issues

- Resolves #104
  - Resolves #367 
  - Resolves #383 
  - Resolves #106  
  - Resolves #107 

## Description

- 브랜치: `feature/fix-series-query-once`
- 관련 이슈: `#104`

이번 PR은 **유스케이스 간 잠재적 순환 의존**을 제거하고, 조회 어댑터/포트 단에서 **스플릿 쿼리(two-step fetch) 전략**을 적용해 **시리즈 + 시리즈 아티클 요약**을 안정적으로 반환하도록 리팩터링합니다.

### 유스케이스 간 잠재적 순환 참조 해결
- **AS-IS**: `SeriesQueryService` → `SeriesArticleReadUseCase` 의존 ⟶ 동일 레벨 간 상호 참조 시 순환참조 위험.
- **TO-BE**: `SeriesQueryService` 가 **단일 Port(`SeriesQueryRepositoryPort`)** 로부터 시리즈와 그 소유 아티클 요약을 **한 번에** 받도록 변경.
  - 필요 시 자바 8+ 환경에서는 **컴포지트(함수 전달)** 방식으로 유스케이스 간 협력을 유도해 순환을 회피.
  - 퍼사드 추가 등 상위 계층 도입도 대안이나, 본 PR에서는 채택하지 않음.

### 스플릿 쿼리: 분할 쿼리로 조회 단계 나누기
- 조인 + `groupBy/transform` 으로 평탄 로우를 재조립하는 방식 대신, 저장소 계층에서 **시리즈 1건**과 **아티클 목록**을 분리 조회하여 합성.
- 기대 효과
  1) **DTO/매퍼 단순화**: 특수 재조립 로직 제거, 팀 온보딩 용이  
  2) **SQL 성능/최적화 용이**: 필요한 컬럼만 타겟팅, 불필요 row 팽창 방지  
  3) **네트워크/메모리 효율**: 중복 전송 감소  
  4) **확장성**: 시리즈 규모 증가 시에도 안정적

<br />

## Review Points

- [ ] `SeriesQueryService` 가 더 이상 `SeriesArticleReadUseCase` 를 참조하지 않는지 (순환참조 해소)
- [ ] `SeriesQueryRepositoryPort.findBySeriesId` 계약이 **시리즈 + 아티클 요약**을 일관되게 반환하는지
- [ ] 스플릿 쿼리 구현에서 **정렬 기준**(예: `series_article.display_order`)과 **페이징/개수 제한** 고려 여부
- [ ] **널/빈 컬렉션 처리**, 예외(`SERIES_NOT_FOUND`) 흐름, 트랜잭션 범위 적절성
- [ ] Query(DSL)/프로젝션 ↔ 읽기모델 매핑 정확성(필드 타입/이름, 생성자 시그니처 일치)
- [ ] 외부 API 스펙(응답 스키마) 변경 없음 확인

<br />
<table border="1" align="center">
<tr>
  <td>
  
  [**리뷰하러 가기**](./384/files)
  
  </td>
</tr>
</table>

<br />

## How Has This Been Tested?

- **실행하여 육안으로 확인하였습니다.**
  - 로컬 프로필에서 시리즈 상세 조회 엔드포인트 호출
  - 시리즈가 아티클 요약 리스트를 포함해 반환되는지 확인
  - 존재하지 않는 ID에 대해 `SERIES_NOT_FOUND` 동작 확인
- 환경: macOS, JDK 21, Gradle 8.10.x, 로컬 Postgres/Redis(Docker)
- **AI 제안**
  - `@DataJpaTest` + Testcontainers 로 스플릿 쿼리 **통합 테스트** 추가
  - **경계 케이스**: 아티클 0개/수백 개, display_order 격차/동률, 널 bannerUrl
  - **계약 테스트**: Port 레벨에서 읽기모델 필드/개수/정렬 보장
  - **성능 스냅샷**: 조인 단일쿼리 vs 스플릿 쿼리 row/전송량 비교(샘플 데이터 기준)

<br />

## Additional Notes

- 비교 보기: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/fix-series-query-once
- 이 Port는 저장소 유형에 독립적입니다(RDB/문서DB 등). 문서DB라면 “한 번에 조회”가 자연스러우며, RDB에서는 내부적으로 스플릿 쿼리로 합성하여 동일 계약을 충족합니다.
- 후속 작업 후보
  - 읽기모델에 **페이징/슬라이싱 파라미터** 도입 검토
  - 시리즈/아티클 **선택 컬럼 최적화** 가이드 문서화

<br />

## 자세한 설명


### 유스케이스 간 잠재적 순환 참조 해결

**순환참조 🔄💥**: 기존 코드는 동일 레벨의 레이어에서 서로 참조하여 순환참조 문제가 발생할 수 있었습니다.   

- **기존 코드**: 시리즈 조회 서비스(use case)가 시리즈 아티클 조회 유스케이스에 의존하였습니다.  
  \: 동일 레벨의 레이어에서 서로 참조한다면 순환참조 문제가 발생할 수 있습니다.
- 만약 Use Case 간 의존이 꼭 필요하다면 자바 8 이상(JDK 1.8+) 환경에서는 컴포지트(함수를 전달하는 방식)를 권합니다.  
  \: 순환 참조가 발생하지 않으면서 서로의 기능을 사용할 수 있습니다.  
  (이 대안 또는 보완재로, 상위에 퍼사드 등 계층을 하나 추가하는 등의 해결책도 있지만 채택하지 않을 것으로 봅니다.)

**💥 AS-IS**

```java
@Service
@RequiredArgsConstructor
public class SeriesQueryService implements SeriesReadUseCase {
    private final SeriesArticleReadUseCase seriesArticleReadUseCase;

    @Override
    public SeriesDetail getSeries(String seriesId) {
        assert seriesId != null;

        var series = queryRepositoryPort.findBySeriesId(seriesId)
                .orElseThrow(SERIES_NOT_FOUND::exception);

        // 시리즈 게시물 조회
        var seriesArticleSummary = seriesArticleReadUseCase.getSeriesArticleList(seriesId);

        // ...

        return series;
    }
}
```

**✅ TO-BE**

💪 시리즈 조회 어댑터가 한 번에 응답하는 구조로 개선합니다.

```java
@Service
@RequiredArgsConstructor
public class SeriesQueryService implements SeriesReadUseCase {

    // 이 포트가 반드시 RDB와 연결되지는 않습니다. 예를 들어 도큐먼트 DB였다면 한 번에 조회하는 것이 충분히 자연스럽습니다.
    private final SeriesQueryRepositoryPort queryRepositoryPort;
    // 🗑️ 이제 이하 코드는 삭제됩니다:
    // private final SeriesArticleReadUseCase seriesArticleReadUseCase;

    @Override
    public SeriesDetail getSeries(String seriesId) {
        assert seriesId != null;
        
        // 동일 도메인 경계 & 소유 관계 데이터: Port에서 시리즈 아티클까지 한 번에 조회합니다.
        return queryRepositoryPort.findBySeriesId(seriesId)
                .orElseThrow(SERIES_NOT_FOUND::exception);
    }
}
```

### 스플릿 쿼리: 분할 쿼리로 조회 단계 나누기

RDB에서는 시리즈와 그 안의 아티클을 계층형으로 조회할 수 없습니다.  
따라서 한 번에 조회하려면, 조인을 붙이는 싱글쿼리에 `groupBy` 및 `transform`으로 flat rows 행들을 애플리케이션 사이드에서 새롭게 구조화합니다.

이때 다음과 같이 발생하는 중복된 데이터로 더 많은 트래픽, 성능상 낮은 메리트 또는 오히려 핸디캡, 낮은 유지보수성을 감수합니다.  
한편 대안이 되는 두 단계 조회는 트래픽 절감, 안정적인 성능, 높은 유지보수성으로 추후 개선에도 유리한 방식으로 생각합니다.

**💥 중복된 데이터를 포함하는 flat rows**

| series_id | blog_id | title     | description | banner_url | display_order | series_article_id | series_article_display_order | article_title |
|----------|---------|-----------|-------------|------------|---------------|-------------------|------------------------------|--------------|
| 1         | 10      | 시리즈1   | 설명1       | /img/1.png | 0             | 101               | 1                            | 게시글A |
| 1         | 10      | 시리즈1   | 설명1       | /img/1.png | 0             | 102               | 2                            | 드래프트B |
| 1         | 10      | 시리즈1   | 설명1       | /img/1.png | 0             | 103               | 3                            | 게시글C |

조회를 두 번 나누어 함으로써 다음과 같은 장점을 얻습니다. (정리는 ChatGPT에 위탁했습니다.)

1. **DTO/매퍼 단순화**  
  `groupBy` + `transform` 은 flat row를 합쳐서 객체 그래프를 다시 만드는 “특수 패턴”이에요.  
  한눈에 안 읽히고, 팀원이 처음 보면 헷갈립니다.  
  반대로 series 따로, seriesArticle 따로 조회하면 매퍼도 단순해지고 유지보수가 훨씬 쉽습니다.  
2. **SQL 성능 & 최적화 용이**  
  두 번으로 나누면 첫 쿼리는 시리즈 1건만 가져오기 (cheap).  
  두 번째 쿼리는 아티클 목록만 가져오기 → 필요한 컬럼만 딱 조회 가능.  
  join 해서 뻥튀기된 row 수를 한 방에 다 가져오는 것보다 효율적일 수 있어요.
3. **네트워크/메모리 효율**  
  join 하면 같은 시리즈 데이터가 수십-수백 번 반복 전송됩니다.  
  두 번으로 나누면 그 중복이 사라집니다.
4. **확장성**  
  지금은 수십-수백 개지만, 나중에 규모가 커져도 이 스플릿 쿼리 전략은 안정적으로 확장 가능합니다.  
  한 쿼리에 다 때려 넣으면 시리즈에 붙은 row가 많아질수록 애플리케이션 메모리 재조립 비용이 증가합니다.  