### PR TITLE
Core > Security: 인가 필터를 우회할 때도 로그인되어 있다면 Authorized Use 정보를 제공합니다.

### DIFF
--- a/core/security/jwt/blolet-jwt-filter/README.md
+++ b/core/security/jwt/blolet-jwt-filter/README.md
@@ -1,43 +1,57 @@
 # JWT 인가 필터 (blolet-jwt-filter)
 
-JWT 토큰을 사용한 인가 처리를 위한 필터 모듈입니다. </br> 
+JWT 토큰을 사용한 인가 처리를 위한 필터 모듈입니다.  
 초기 복잡성을 줄이기 위해 스프링 시큐리티 없이 구현합니다.
 
 ## 1. 주요 기능
 
-- **인가 정책**: 인가가 필요하지 않은 경로에서의 요청은 통과
-- **JWT 토큰 검증**: HTTP 요청의 Authorization 헤더에서 JWT 토큰을 추출하고 검증
-- **@AuthUser 어노테이션**: 컨트롤러에서 JWT 사용자 정보를 자동으로 주입받을 수 있는 커스텀 어노테이션
+- **인가 정책**: 인가가 필요하지 않은 경로에서의 요청은 통과 (Bypass)
+- **JWT 토큰 검증**: HTTP 요청의 `Authorization` 헤더에서 `Bearer ` JWT를 추출하고 검증
+- **`@AuthUser` 애노테이션**: 컨트롤러 메서드 파라미터에 로그인 사용자 정보를 자동으로 주입받음을 지시하는 커스텀 애노테이션
+
+### 지원 파라미터 타입
+
+이하 타입으로 선언한 파라미터에 `@AuthUser`를 붙일 수 있습니다.
+
+- `AuthorizedUser`
+- `Optional<AuthorizedUser>`
+
+### 파라미터 타입별 인가 여부에 따른 기본값
+
+- 인가가 필요한 요청
+  - 주입 전 필터 단계에서 예외가 발생합니다.
+- 인가를 거치지 않는 요청
+  - `AuthorizedUser`: `null`이 주입될 수 있습니다.
+  - `Optional<AuthorizedUser>`: `Optional.empty()`가 주입될 수 있습니다.
 
 ## 2. 의존성
-- `jwt-parser`: JWT 토큰 파싱 및 검증
+
+- `jwt-parser` 모듈: JWT 토큰 파싱 및 검증
 - `spring-boot-starter-web`: 스프링 웹 필터를 사용하기 위함
-
-
 
 ## 3. 사용 예시
 ### - @AuthUser 어노테이션 사용
 
-컨트롤러에서 `@AuthUser` 어노테이션을 사용하여 JWT 사용자 정보를 자동으로 주입받을 수 있습니다.
+컨트롤러 메서드 파라미터에서 `@AuthUser` 애노테이션 및 `AuthorizedUser` 객체로 인증된 사용자 정보를 자동으로 주입받을 수 있습니다.  
 
 ```java
 @RestController
 public class ExampleController {
-    
+
     @GetMapping("/user-info")
     public ResponseEntity<String> getUserInfo(@AuthUser AuthorizedUser user) {
         // user 객체에 JWT 정보가 자동으로 주입됨
         String userId = user.getUserId();
         List<String> profileIds = user.getProfileIds();
-        
+
         if (user.hasRole("ADMIN")) {
             return ResponseEntity.ok("Admin access granted");
         }
-        
+
         if (user.hasProfileId("wch-os")) {
             return ResponseEntity.ok("Profile access granted");
         }
-        
+
         return ResponseEntity.ok("User info: " + userId);
     }
 }
@@ -55,4 +69,8 @@ JWT 토큰 검증 실패 시 다음과 같은 응답을 반환합니다.
 }
 ```
 
+세 가지 케이스에 대하여 예외 처리를 합니다.
 
+- 토큰 만료
+- 토큰이 유효하지 않음 (잘못된 시그니처)
+- 토큰이 존재하지 않음. (인가가 필요할 때)

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
@@ -66,7 +66,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             sendUnauthorizedResponse(response, "JWT 토큰이 유효하지 않습니다.", e.getMessage());
         } catch (JwtParsingException e) {
             if (e.getErrorCode() != JWT_ACCESS_TOKEN_REQUIRED) {
-                log.debug("에러 코드: " + e.getErrorCode());
+                log.debug("에러 코드: {}", e.getErrorCode());
                 throw e;
             }
             log.debug("JWT 토큰이 존재하지 않습니다.");
@@ -93,7 +93,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             log.debug("JWT 토큰이 유효하지 않습니다.");
         } catch (JwtParsingException e) {
             if (e.getErrorCode() != JWT_ACCESS_TOKEN_REQUIRED) {
-                log.debug("에러 코드: " + e.getErrorCode());
+                log.debug("에러 코드: {}", e.getErrorCode());
                 throw e;
             }
             log.debug("JWT 토큰이 존재하지 않습니다.");

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
@@ -10,8 +10,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nettee.blolet.jwt.filter.annotation.AuthorizedUser;
-import nettee.blolet.jwt.filter.exception.PathFilterException;
 import nettee.jwt.parser.JwtParser;
+import nettee.jwt.parser.exception.JwtParsingException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.server.PathContainer;
 import org.springframework.stereotype.Component;
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 
-import static nettee.blolet.jwt.filter.exception.PathFilterErrorCode.AUTH_ACCESS_TOKEN_REQUIRED;
+import static nettee.jwt.parser.exception.JwtParserErrorCode.JWT_ACCESS_TOKEN_REQUIRED;
 
 /**
  * JWT 인가 필터
@@ -48,7 +48,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         try {
             // 3. JWT 토큰 검증 및 파싱
             // 4. JWT 토큰에서 사용자 정보 추출
-            parseHeaderAndSetRequestAttribute(request, true);
+            parseHeaderAndSetRequestAttribute(request);
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             // 토큰이 만료된 경우, 리프레시 토큰 요청 경로는 통과
@@ -64,7 +64,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         } catch (JwtException e) {
             log.error("JWT 토큰이 유효하지 않습니다.");
             sendUnauthorizedResponse(response, "JWT 토큰이 유효하지 않습니다.", e.getMessage());
-        } catch (PathFilterException e) {
+        } catch (JwtParsingException e) {
+            if (e.getErrorCode() != JWT_ACCESS_TOKEN_REQUIRED) {
+                log.debug("에러 코드: " + e.getErrorCode());
+                throw e;
+            }
+            log.debug("JWT 토큰이 존재하지 않습니다.");
             sendUnauthorizedResponse(response, "JWT 토큰이 존재하지 않습니다.", "Authorization 헤더에 JWT 토큰이 존재하지 않습니다.");
         }
     }
@@ -81,12 +86,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         try {
             // 3. JWT 토큰 검증 및 파싱
             // 4. JWT 토큰에서 사용자 정보 추출
-            parseHeaderAndSetRequestAttribute(request, false);
+            parseHeaderAndSetRequestAttribute(request);
         } catch (ExpiredJwtException e) {
             log.debug("JWT 토큰이 만료되었습니다.");
         } catch (JwtException e) {
             log.debug("JWT 토큰이 유효하지 않습니다.");
-        } catch (PathFilterException e) {
+        } catch (JwtParsingException e) {
+            if (e.getErrorCode() != JWT_ACCESS_TOKEN_REQUIRED) {
+                log.debug("에러 코드: " + e.getErrorCode());
+                throw e;
+            }
             log.debug("JWT 토큰이 존재하지 않습니다.");
         }
 
@@ -102,21 +111,14 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
      *
      * @throws ExpiredJwtException 만료
      * @throws JwtException 애초에 유효하지도 않은 토큰을 넣어?
+     * @throws JwtParsingException {@link JWT_ACCESS_TOKEN_REQUIRED} 에러코드라면 액세스 토큰이 존재하지 않음.
      */
-    private void parseHeaderAndSetRequestAttribute(HttpServletRequest request, boolean isRequired)
-            throws JwtException, PathFilterException {
-        String requestURI = request.getRequestURI();
-        String method = request.getMethod();
-
+    private void parseHeaderAndSetRequestAttribute(HttpServletRequest request)
+            throws JwtException, JwtParsingException {
         // 1. Authorization 헤더에서 JWT 토큰 추출
         String jwtToken = extractJwtToken(request);
 
-        // 2. JWT 토큰이 없으면 401 Unauthorized 응답
-        if (!StringUtils.hasText(jwtToken)) {
-            log.warn("JWT 토큰이 존재하지 않습니다. [{}]: {}", method, requestURI);
-            throw AUTH_ACCESS_TOKEN_REQUIRED.exception();
-        }
-
+        // 2. JWT 토큰이 없으면 JwtParsingException 및 JWT_ACCESS_TOKEN_REQUIRED 던짐. (401 Unauthorized)
         // 3. JWT 토큰 검증 및 파싱
         var claims = jwtParser.parseClaims(jwtToken);
 

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/JwtAuthorizationFilter.java
@@ -9,7 +9,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nettee.blolet.jwt.filter.annotation.AuthorizedUser;
+import nettee.blolet.jwt.filter.exception.PathFilterException;
 import nettee.jwt.parser.JwtParser;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.server.PathContainer;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -18,6 +21,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+
+import static nettee.blolet.jwt.filter.exception.PathFilterErrorCode.AUTH_ACCESS_TOKEN_REQUIRED;
 
 /**
  * JWT 인가 필터
@@ -35,33 +40,19 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
      * HTTP 요청을 필터링합니다.
      */
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                  HttpServletResponse response,
-                                  FilterChain filterChain) throws IOException, ServletException {
-
-        String requestURI = request.getRequestURI();
-        String method = request.getMethod();
-
-        // 1. Authorization 헤더에서 JWT 토큰 추출
-        String jwtToken = extractJwtToken(request);
-
-        // 2. JWT 토큰이 없으면 401 Unauthorized 응답
-        if (!StringUtils.hasText(jwtToken)) {
-            log.warn("JWT 토큰이 존재하지 않습니다. [{}]: {}", method, requestURI);
-            sendUnauthorizedResponse(response, "JWT 토큰이 존재하지 않습니다.", "Authorization 헤더에 JWT 토큰이 존재하지 않습니다.");
-            return;
-        }
-
+    protected void doFilterInternal(
+            @NotNull HttpServletRequest request,
+            @NotNull HttpServletResponse response,
+            FilterChain filterChain
+    ) throws IOException, ServletException {
         try {
             // 3. JWT 토큰 검증 및 파싱
-            var claims = jwtParser.parseClaims(jwtToken);
-
             // 4. JWT 토큰에서 사용자 정보 추출
-            setRequestAttribute(request, claims);
-
+            parseHeaderAndSetRequestAttribute(request, true);
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             // 토큰이 만료된 경우, 리프레시 토큰 요청 경로는 통과
+            String requestURI = request.getRequestURI();
             if (requestURI.equals("/auth/token/refresh")) {
                 var claims = e.getClaims();
                 setRequestAttribute(request, claims);
@@ -73,16 +64,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         } catch (JwtException e) {
             log.error("JWT 토큰이 유효하지 않습니다.");
             sendUnauthorizedResponse(response, "JWT 토큰이 유효하지 않습니다.", e.getMessage());
+        } catch (PathFilterException e) {
+            sendUnauthorizedResponse(response, "JWT 토큰이 존재하지 않습니다.", "Authorization 헤더에 JWT 토큰이 존재하지 않습니다.");
         }
-    }
-
-    /**
-     * JWT 토큰에서 사용자 정보를 추출하여 요청 속성에 설정합니다.
-     */
-    private void setRequestAttribute(HttpServletRequest request, Claims claims) {
-        request.setAttribute("userId", claims.getSubject());
-        request.setAttribute("roles", claims.get("roles", List.class));
-        request.setAttribute("profileIds", claims.get("profileIds", List.class));
     }
 
     /**
@@ -94,11 +78,66 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         PathContainer pathContainer = PathContainer.parsePath(requestURI);
         String method = request.getMethod();
 
+        try {
+            // 3. JWT 토큰 검증 및 파싱
+            // 4. JWT 토큰에서 사용자 정보 추출
+            parseHeaderAndSetRequestAttribute(request, false);
+        } catch (ExpiredJwtException e) {
+            log.debug("JWT 토큰이 만료되었습니다.");
+        } catch (JwtException e) {
+            log.debug("JWT 토큰이 유효하지 않습니다.");
+        } catch (PathFilterException e) {
+            log.debug("JWT 토큰이 존재하지 않습니다.");
+        }
+
         // pattern 매칭을 통해 필터링 제외 경로인지 확인
         var patternSet = methodPathPatternParser.getExcludePathsByMethod(method);
         assert patternSet != null;
         return patternSet.stream()
                 .anyMatch(pattern -> pattern.matches(pathContainer));
+    }
+
+    /**
+     * JWT 토큰에서 사용자 정보를 추출하여 요청 속성에 설정합니다.
+     *
+     * @throws ExpiredJwtException 만료
+     * @throws JwtException 애초에 유효하지도 않은 토큰을 넣어?
+     */
+    private void parseHeaderAndSetRequestAttribute(HttpServletRequest request, boolean isRequired)
+            throws JwtException, PathFilterException {
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 1. Authorization 헤더에서 JWT 토큰 추출
+        String jwtToken = extractJwtToken(request);
+
+        // 2. JWT 토큰이 없으면 401 Unauthorized 응답
+        if (!StringUtils.hasText(jwtToken)) {
+            log.warn("JWT 토큰이 존재하지 않습니다. [{}]: {}", method, requestURI);
+            throw AUTH_ACCESS_TOKEN_REQUIRED.exception();
+        }
+
+        // 3. JWT 토큰 검증 및 파싱
+        var claims = jwtParser.parseClaims(jwtToken);
+
+        // 4. JWT 토큰에서 사용자 정보 추출 → 인스턴스화
+        setRequestAttribute(request, claims);
+    }
+
+    /**
+     * JWT 토큰의 클레임 목록에서 사용자 정보를 추출하여 요청 속성에 설정합니다.
+     */
+    private void setRequestAttribute(HttpServletRequest request, Claims claims) {
+        @SuppressWarnings("unchecked")
+        var authUser = new AuthorizedUser(
+                claims.getSubject(),
+                claims.get("roles", List.class),
+                claims.get("profileIds", List.class)
+        );
+
+        // K: Full Qualified Class Name
+        // V: auth user
+        request.setAttribute(AuthorizedUser.class.getTypeName(), authUser);
     }
 
     /**

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/exception/PathFilterErrorCode.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/exception/PathFilterErrorCode.java
@@ -7,7 +7,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public enum PathFilterErrorCode implements ErrorCode {
-    AUTH_FILTER_PATH_NOT_ENTERED(HttpStatus.INTERNAL_SERVER_ERROR, "경로를 입력해야 합니다.")
+    AUTH_FILTER_PATH_NOT_ENTERED(HttpStatus.INTERNAL_SERVER_ERROR, "경로를 입력해야 합니다."),
+    AUTH_ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 입력되지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/exception/PathFilterErrorCode.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/exception/PathFilterErrorCode.java
@@ -8,7 +8,6 @@ import java.util.function.Supplier;
 
 public enum PathFilterErrorCode implements ErrorCode {
     AUTH_FILTER_PATH_NOT_ENTERED(HttpStatus.INTERNAL_SERVER_ERROR, "경로를 입력해야 합니다."),
-    AUTH_ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 입력되지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/resolver/AuthUserArgumentResolver.java
@@ -5,11 +5,14 @@ import lombok.RequiredArgsConstructor;
 import nettee.blolet.jwt.filter.annotation.AuthUser;
 import nettee.blolet.jwt.filter.annotation.AuthorizedUser;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Optional;
 
 /**
  * @AuthUser 어노테이션이 붙은 파라미터를 처리하여 AuthorizedUser 객체를 주입하는 ArgumentResolver
@@ -20,8 +23,22 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(AuthUser.class)
-                && parameter.getParameterType().equals(AuthorizedUser.class);
+        // 얼리리턴
+        if (!parameter.hasParameterAnnotation(AuthUser.class)) {
+            return false;
+        }
+        // AuthorizedUser 직접 타입
+        if (parameter.getParameterType().equals(AuthorizedUser.class)) {
+            return true;
+        }
+
+        // Optional<AuthorizedUser> 제네릭 타입
+        if (parameter.getParameterType().equals(Optional.class)) {
+            Class<?> genericType = ResolvableType.forMethodParameter(parameter).getGeneric(0).resolve();
+            return AuthorizedUser.class.equals(genericType);
+        }
+
+        return false;
     }
 
     @Override
@@ -32,7 +49,12 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             WebDataBinderFactory binderFactory
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        return request.getAttribute(AuthorizedUser.class.getTypeName());
+        var user = request.getAttribute(AuthorizedUser.class.getTypeName());
+
+        if (parameter.getParameterType().equals(Optional.class)) {
+            return Optional.ofNullable(user);
+        }
+
+        return user;
     }
 }
-

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/resolver/AuthUserArgumentResolver.java
@@ -49,7 +49,7 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             WebDataBinderFactory binderFactory
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        var user = request.getAttribute(AuthorizedUser.class.getTypeName());
+        AuthorizedUser user = (AuthorizedUser) request.getAttribute(AuthorizedUser.class.getTypeName());
 
         if (parameter.getParameterType().equals(Optional.class)) {
             return Optional.ofNullable(user);

--- a/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/resolver/AuthUserArgumentResolver.java
+++ b/core/security/jwt/blolet-jwt-filter/src/main/java/nettee/blolet/jwt/filter/resolver/AuthUserArgumentResolver.java
@@ -1,7 +1,6 @@
 package nettee.blolet.jwt.filter.resolver;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import nettee.blolet.jwt.filter.annotation.AuthUser;
 import nettee.blolet.jwt.filter.annotation.AuthorizedUser;
@@ -26,18 +25,14 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter,
-                                  ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
-
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-
-        String userId = (String) request.getAttribute("userId");
-        @SuppressWarnings("unchecked") List<String> roles = (List<String>) request.getAttribute("roles");
-        @SuppressWarnings("unchecked") List<String> profileIds = (List<String>) request.getAttribute("profileIds");
-
-        return new AuthorizedUser(userId, roles, profileIds);
+        return request.getAttribute(AuthorizedUser.class.getTypeName());
     }
 }
 

--- a/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/JwtParser.java
+++ b/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/JwtParser.java
@@ -13,6 +13,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.SecretKey;
 
+import static nettee.jwt.parser.exception.JwtParserErrorCode.JWT_ACCESS_TOKEN_REQUIRED;
+
 public final class JwtParser {
 
     private final JwtParserBuilder jwtParserBuilder;
@@ -43,6 +45,8 @@ public final class JwtParser {
      * 이 과정에서 서명 검증, 만료 시간 체크가 수행됩니다.
      */
     public Claims parseClaims(String token) throws JwtException {
+        if (token == null || token.isBlank()) throw JWT_ACCESS_TOKEN_REQUIRED.exception();
+
         return jwtParserBuilder
                 .build()
                 .parseSignedClaims(token)

--- a/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/exception/JwtParserErrorCode.java
+++ b/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/exception/JwtParserErrorCode.java
@@ -1,0 +1,60 @@
+package nettee.jwt.parser.exception;
+
+import nettee.common.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public enum JwtParserErrorCode implements ErrorCode {
+    JWT_ACCESS_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 입력되지 않습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    JwtParserErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public JwtParsingException exception() {
+        return new JwtParsingException(this);
+    }
+
+    @Override
+    public JwtParsingException exception(Throwable cause) {
+        return new JwtParsingException(this, cause);
+    }
+
+    @Override
+    public JwtParsingException exception(Runnable runnable) {
+        return new JwtParsingException(this, runnable);
+    }
+
+    @Override
+    public JwtParsingException exception(Runnable runnable, Throwable cause) {
+        return new JwtParsingException(this, runnable, cause);
+    }
+
+    @Override
+    public JwtParsingException exception(Supplier<Map<String, Object>> appendPayload) {
+        return new JwtParsingException(this, appendPayload);
+    }
+
+    @Override
+    public JwtParsingException exception(Supplier<Map<String, Object>> appendPayload, Throwable cause) {
+        return new JwtParsingException(this, appendPayload, cause);
+    }
+}

--- a/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/exception/JwtParsingException.java
+++ b/core/security/jwt/jwt-parser/src/main/java/nettee/jwt/parser/exception/JwtParsingException.java
@@ -1,0 +1,57 @@
+package nettee.jwt.parser.exception;
+
+import nettee.common.CustomException;
+import nettee.common.ErrorCode;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class JwtParsingException extends CustomException {
+    public JwtParsingException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public JwtParsingException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    public JwtParsingException(ErrorCode errorCode, Runnable runnable) {
+        super(errorCode, runnable);
+    }
+
+    public JwtParsingException(ErrorCode errorCode, Runnable runnable, Throwable cause) {
+        super(errorCode, runnable, cause);
+    }
+
+    public JwtParsingException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier) {
+        super(errorCode, payloadSupplier);
+    }
+
+    public JwtParsingException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        super(errorCode, payloadSupplier, cause);
+    }
+
+    public JwtParsingException() {
+        super();
+    }
+
+    public JwtParsingException(Throwable cause) {
+        super(cause);
+    }
+
+    public JwtParsingException(Runnable runnable) {
+        super(runnable);
+    }
+
+    public JwtParsingException(Runnable runnable, Throwable cause) {
+        super(runnable, cause);
+    }
+
+    public JwtParsingException(Supplier<Map<String, Object>> payloadSupplier) {
+        super(payloadSupplier);
+    }
+
+    public JwtParsingException(Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        super(payloadSupplier, cause);
+    }
+}


### PR DESCRIPTION
<br /><br />

<table border="3" align="center">
<tr height="45">
  <td width="45" align="center">🤖</td>
  <td align="center"><strong>이 문서는 인공지능으로 작성하였습니다.</strong></td>
</tr>
</table>

<br />

## Issues

- Resolves #392

## Description

- `JwtAuthorizationFilter`의 bypass 대상 경로에서도, **요청에 JWT가 존재하면 사용자 정보를 해석해 컨트롤러 파라미터로 주입**하도록 개선했습니다. (#392)
- `@AuthUser` 파라미터 전용 `AuthUserArgumentResolver`를 추가하여 다음 정책을 보장합니다.
  - 토큰이 **정상**: `AuthorizedUser(userId, roles, profileIds)` 주입
  - 토큰이 **없음/무효/만료**: 예외 없이 `null` 주입 또는 `Optional.empty()` 주입 (보안 필터를 우회한 공개 엔드포인트의 UX 유지)
- 토큰 파싱 책임을 `JwtParser`로 **이관/정리**하고, 오류 코드를 파서 레이어로 **통합**(enum)하여 재사용성과 로깅 일관성 확보.
- 보안 행태 변화 없음: 보호된 경로에서는 기존과 동일하게 필터가 인가합니다.

<br />

## Review Points

- `HandlerMethodArgumentResolver` 등록 순서 및 우선순위가 Spring Security 기본 리졸버/Principal 리졸버와 충돌하지 않는지 확인해 주세요.
- 사용자 컨텍스트 주입 경로
  - (1) 필터에서 `request.setAttribute(...)`로 저장된 `AuthorizedUser`
  - (2) 토큰 기반 파싱 실패/부재 시의 **게스트 전략**(Null Object vs `null`) 일관성
- 컨트롤러 시그니처 다양성 대응
  - `AuthorizedUser` 직접 주입, `Optional<AuthorizedUser>`, `@Nullable AuthorizedUser` 등 케이스에서의 동작
- 보안 관점
  - 필터 우회 경로에서 **권한 검증이 필요한 API가 잘못 노출되지 않도록**(컨트롤러/서비스 단 보호) 가이드/어설션이 충분한지
- 추후 확장
  - `@AuthUser`에 `required` 옵션 도입 필요성 여부
  - 다중 인증 소스(헤더, 쿠키, 세션, 내부 프록시) 통합 정책

<br />
<table border="1" align="center">
<tr>
  <td>
  
  [**리뷰하러 가기**](./402/files)
  
  </td>
</tr>
</table>

<br />

## How Has This Been Tested?

- 실행하여 육안으로 확인하였습니다.
- 로컬 환경(`docker-compose` 기반, `SPRING_PROFILES_ACTIVE=local`)에서 다음을 수동 검증했습니다.
  - 인증 필터 **적용 경로**: 유효 토큰 → 컨트롤러에서 `@AuthUser`가 기대값으로 주입됨.
  - 인증 필터 **우회 경로**: 토큰 부재/무효 → 컨트롤러에서 `@AuthUser`가 게스트(또는 `null/Optional.empty`)로 안전 주입되어 NPE 없이 처리됨.
  - 동일 컨트롤러 메서드에서 `Principal`/`@AuthUser` 병행 시 충돌 없음.
- 실행하여 육안으로 확인하였습니다.
- AI 제안
  - MVC 슬라이스 테스트 작성: `@WebMvcTest` + 커스텀 리졸버 등록 검증, 파라미터 조합(직접/Optional/Nullable)별 바인딩 결과 단언.
  - 통합 테스트: 필터 우회/적용 라우트 각각에 대해 200/401/403 응답 행태 및 바인딩 값 스냅샷 테스트.
  - 퍼포먼스: 고 QPS 환경에서 리졸버가 불필요한 파싱/IO를 수행하지 않는지(요청 속성 캐시 활용) 점검.

<br />

## Additional Notes

- 브랜치 비교 링크: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/core-auth-resolve-user-despite-filter-bypass
- 이후 단계에서 `@AuthUser(required=true)` 옵션을 도입하면, 인증이 필수인 엔드포인트에서 리졸버 레벨에서 401 반환(또는 예외 전환)까지 일관 처리하는 확장이 가능합니다.