### PR TITLE
Monolith > Flyway: Article 테이블에 draft_id 컬럼을 추가합니다. 또한 더미데이터에 반영합니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
@@ -169,7 +169,7 @@ INSERT INTO "article"."draft" (
             WHEN gs BETWEEN 54 AND 58  THEN current_setting('dummy.DRAFT_SUSPENDED')::int   -- SUSPENDED
             WHEN gs BETWEEN 59 AND 110 THEN current_setting('dummy.DRAFT_PENDING')::int     -- PENDING
             ELSE current_setting('dummy.DRAFT_REMOVED')::int                                -- REMOVED
-            END AS status
+        END AS status
     FROM generate_series(1, 115) gs;
 
 -- ─────────────────────────────────────────────────────────────────────────────
@@ -205,7 +205,8 @@ WITH
         -- ACTIVE
         SELECT
             p.blog_id,
-            p.title,
+            p.id AS draft_id,
+            p.title || '_article' AS title,
             p."path",
             current_setting('dummy.ARTICLE_ACTIVE')::int AS article_status,
             p.rn AS ord
@@ -214,7 +215,8 @@ WITH
             -- SUSPENDED
             SELECT
                 p.blog_id,
-                p.title,
+                p.id AS draft_id,
+                p.title || '_article' AS title,
                 p."path",
                 current_setting('dummy.ARTICLE_SUSPENDED')::int AS article_status,
                 p.rn
@@ -223,7 +225,8 @@ WITH
             -- REMOVED
             SELECT
                 r.blog_id,
-                r.title,
+                r.id AS draft_id,
+                r.title || '_article' AS title,
                 r."path",
                 current_setting('dummy.ARTICLE_REMOVED')::int AS article_status,
                 r.id::bigint
@@ -233,6 +236,7 @@ WITH
         INSERT INTO "article"."article" (
             id,
             blog_id,
+            draft_id,
             title,
             "path",
             status,
@@ -250,6 +254,7 @@ WITH
                 )
             )::bigint AS id,
             blog_id,
+            draft_id,
             title,
             "path",
             article_status,
@@ -310,7 +315,9 @@ WITH
     ),
     active_susp_articles AS (
         SELECT
-            a.id, ROW_NUMBER() OVER (ORDER BY a.id) AS rn
+            a.id,
+            a.draft_id,
+            ROW_NUMBER() OVER (ORDER BY a.id) AS rn
         FROM "article"."article" a
         WHERE
             a.blog_id = current_setting('dummy.BLOG_ID')::bigint
@@ -319,6 +326,9 @@ WITH
                 current_setting('dummy.ARTICLE_ACTIVE')::int,
                 current_setting('dummy.ARTICLE_SUSPENDED')::int
             )
+    ),
+    active_susp_count AS (
+        SELECT COUNT(*) AS cnt FROM active_susp_articles
     ),
     ins_pending AS (
         -- PENDING drafts 52개
@@ -330,8 +340,9 @@ WITH
         SELECT
             f.sid,
             p.id,
-            p.rn
+            p.rn + c.cnt
         FROM first_series f
+            CROSS JOIN active_susp_count c
             JOIN (SELECT * FROM pending_drafts ORDER BY rn LIMIT 52) p
                 ON TRUE
             RETURNING 1
@@ -340,11 +351,13 @@ WITH
 INSERT INTO "article"."series_article" (
     series_id,
     article_id,
+    draft_id,
     display_order
 )
 SELECT
     f.sid,
     a.id,
+    a.draft_id,
     a.rn
 FROM first_series f
     JOIN active_susp_articles a

--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_11__create_tb_article.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_11__create_tb_article.sql
@@ -3,6 +3,7 @@ CREATE SCHEMA IF NOT EXISTS article;
 CREATE TABLE IF NOT EXISTS article.article (
     id          BIGINT,
     blog_id     BIGINT,
+    draft_id     BIGINT,
     entry_block_id BIGINT,
 
     title       VARCHAR(255),
@@ -22,6 +23,7 @@ CREATE TABLE IF NOT EXISTS article.article (
 -- 컬럼 코멘트
 COMMENT ON COLUMN article.article.id            IS 'Article PK';
 COMMENT ON COLUMN article.article.blog_id       IS '블로그 ID';
+COMMENT ON COLUMN article.article.draft_id      IS '편집용 임시글 ID';
 COMMENT ON COLUMN article.article.entry_block_id IS '첫 블록 ID';
 COMMENT ON COLUMN article.article.title         IS '제목';
 COMMENT ON COLUMN article.article.content       IS '본문';
@@ -35,3 +37,4 @@ COMMENT ON COLUMN article.article.updated_at    IS '마지막 수정시간';
 
 ALTER TABLE "article"."article" ADD CONSTRAINT "pk_article" PRIMARY KEY ("id");
 ALTER TABLE "article"."article" ADD CONSTRAINT "uq_article_blog_id_path" UNIQUE ("blog_id", "path");
+ALTER TABLE "article"."article" ADD CONSTRAINT "uq_article_draft_id" UNIQUE ("draft_id");


### PR DESCRIPTION

<br /><br />

<table border="3" align="center">
<tr height="45">
  <td width="45" align="center">🤖</td>
  <td align="center"><strong>이 문서는 인공지능으로 작성하였습니다.</strong></td>
</tr>
</table>

<br />

## Issues

- Resolves #404
- Resolves #405

## Description

- 스키마 변경 (article.article)
  - `draft_id BIGINT` 컬럼 추가 및 컬럼 코멘트: *편집용 임시글 ID*.
  - 유니크 제약 추가: `uq_article_draft_id (draft_id)` (PostgreSQL 특성상 `NULL`은 중복 허용).
  - 기존 유니크 제약 유지: `uq_article_blog_id_path (blog_id, path)`.
- 로컬/DEV 더미 스크립트 보강 (`R__init_dummies.sql`)
  - Article 생성 시 **드래프트 ID 주입**: `p.id/r.id AS draft_id`로 선택, `INSERT article(..., draft_id, ...) SELECT ...`.
  - 더미 Article 타이틀 규칙: `title || '_article'`로 명시적 구분.
  - `active_susp_articles` CTE에 `draft_id` 포함, 후속 참조 일관화.
  - `active_susp_count` CTE 도입으로 **display_order 오프셋을 동적 계산**(`p.rn + c.cnt`)
  - `series_article` 더미 적재 시 `draft_id` 컬럼 추가 및 `a.draft_id`/`p.id` 연계 삽입.
- 주의 사항
  - <del>이미 적용된 환경에서 `V1_0_11__create_tb_article.sql` 수정분은 Flyway 체크섬 충돌을 야기할 수 있으므로 **clean 또는 재기동 전략**이 필요합니다.</del>
    - 다음 명령으로 DB 초기화 후 마이그레이션을 진행해 주세요.  
    ```shell
    ./monolith-compose down -v
    ./monolith-compose up -d
    ```
- 관련 이슈: #403  
- 참고: [비교 링크( develop...feature/flyway )](https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/flyway)

<br />

## Review Points

- **제약/무결성**
  - `draft_id` 유니크 추가로 *Article:Draft = 1:1(NOT NULL 기준)* 제약 형성 — 기존/향후 데이터 충돌 가능성 점검.
  - FK는 현 변경에 포함되지 않음(<del>필요 시 별도 `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` 논의</del>).
- **더미 데이터 일관성**
  - `series_article(article_id, draft_id, display_order)` 적재 후, **<ins>아티클 존재 시 드래프트 중복 노출 방지</ins>가** 쿼리에서 보장되는지 확인.
  - `display_order`가 `active+susp` 개수에 종속되므로 데이터 건수 변경 시에도 안정적으로 정렬되는지 재확인.
- **마이그레이션 운영 영향**
  - V 스크립트 수정에 따른 Flyway 체크섬 대응(개발/CI 환경은 clean, 운영은 불가) 방침 확인.
  - 인덱싱 필요성 검토: `draft_id` 조인/조회 빈도에 따라 보조 인덱스 고려.

<br />
<table border="1" align="center">
<tr>
  <td>
  
  [**리뷰하러 가기**](./406/files)
  
  </td>
</tr>
</table>

<br />

## How Has This Been Tested?

- 로컬(PostgreSQL 14, JDK 21)에서 마이그레이션 적용 후 더미 데이터 적재 결과 육안 확인.
- `series_article` 조회 시 기사 존재 시 드래프트 중복 노출 여부 수동 검증.
- 실행하여 육안으로 확인하였습니다.
- AI 제안
  - Testcontainers 스모크: `clean → migrate → 제약/중복/조인 무결성 쿼리` 자동 검증.
  - `article(draft_id)` 보조 인덱스 도입 여부 벤치마크.
  - 더미 스크립트 내 오프셋 계산 로직을 함수/뷰로 캡슐화해 재사용성↑.

<br />

## Additional Notes

- 비교 링크: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/flyway