### PR TITLE
Blog: 사용자가 소유한 블로그 집합(Set)을 반환하는 내부 통신 엔드포인트를 만들고, 클라이언트가 이를 이용합니다.

### DIFF
--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogQueryRepositoryPort.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/port/BlogQueryRepositoryPort.java
@@ -10,4 +10,5 @@ import java.util.Set;
 public interface BlogQueryRepositoryPort {
     Optional<Blog> findById(String id);
     Map<String, UserProfileBlogs> findAllByProfileIdIn(Set<String> userIds);
+    Set<String> findBlogIdsByUserId(String userId);
 }

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogQueryService.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/service/BlogQueryService.java
@@ -31,6 +31,11 @@ public class BlogQueryService implements BlogReadUseCase, BlogOwnershipVerifyUse
     }
 
     @Override
+    public Set<String> findBlogIdsByUserId(String userId) {
+        return repository.findBlogIdsByUserId(userId);
+    }
+
+    @Override
     public boolean verifyOwnershipByUserId(String userId, String blogId) {
         var blog = repository.findById(blogId)
                 .orElseThrow(BLOG_NOT_FOUND::exception);

--- a/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogReadUseCase.java
+++ b/services/blog/application/src/main/java/nettee/blolet/blog/application/usecase/BlogReadUseCase.java
@@ -9,4 +9,5 @@ import java.util.Set;
 public interface BlogReadUseCase {
     Blog findById(String blogId);
     Map<String, UserProfileBlogs> findByUserProfileIds(Set<String> profileIds);
+    Set<String> findBlogIdsByUserId(String userId);
 }

--- a/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/RdbBlogQueryRepositoryAdapter.java
+++ b/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/RdbBlogQueryRepositoryAdapter.java
@@ -5,12 +5,14 @@ import nettee.blolet.blog.application.port.BlogQueryRepositoryPort;
 import nettee.blolet.blog.domain.Blog;
 import nettee.blolet.blog.rdb.mapper.BlogEntityMapper;
 import nettee.blolet.blog.rdb.repository.BlogQueryJpaRepository;
+import nettee.blolet.blog.rdb.repository.projection.BlogQueryProjection.BlogIdProjection;
 import nettee.blolet.blog.readmodel.BlogReadModels.UserProfileBlogs;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,5 +31,14 @@ public class RdbBlogQueryRepositoryAdapter implements BlogQueryRepositoryPort {
     @Override
     public Map<String, UserProfileBlogs> findAllByProfileIdIn(Set<String> userIds) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Set<String> findBlogIdsByUserId(String userId) {
+        Long userIdLong = Long.valueOf(userId);
+        return queryJpaRepository.findBlogIdByUserId(userIdLong).stream()
+                .map(BlogIdProjection::id)
+                .map(String::valueOf)
+                .collect(Collectors.toSet());
     }
 }

--- a/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/repository/BlogQueryJpaRepository.java
+++ b/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/repository/BlogQueryJpaRepository.java
@@ -1,7 +1,11 @@
 package nettee.blolet.blog.rdb.repository;
 
 import nettee.blolet.blog.rdb.entity.BlogEntity;
+import nettee.blolet.blog.rdb.repository.projection.BlogQueryProjection.BlogIdProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Set;
+
 public interface BlogQueryJpaRepository extends JpaRepository<BlogEntity, Long> {
+    Set<BlogIdProjection> findBlogIdByUserId(Long userId);
 }

--- a/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/repository/projection/BlogQueryProjection.java
+++ b/services/blog/driven/rdb/src/main/java/nettee/blolet/blog/rdb/repository/projection/BlogQueryProjection.java
@@ -1,0 +1,7 @@
+package nettee.blolet.blog.rdb.repository.projection;
+
+public final class BlogQueryProjection {
+    private BlogQueryProjection() {}
+
+    public record BlogIdProjection(Long id) { }
+}

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/BlogInternalQueryApi.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/BlogInternalQueryApi.java
@@ -1,0 +1,26 @@
+package nettee.blolet.blog.web.admin;
+
+import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.application.usecase.BlogReadUseCase;
+import nettee.blolet.blog.web.admin.dto.BlogInternalQueryDto.BlogIdsQueryResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("internal")
+public class BlogInternalQueryApi {
+
+    private final BlogReadUseCase useCase;
+
+    @GetMapping("/users/{userId}/blog-id")
+    public BlogIdsQueryResponse getBlogIds(
+            @PathVariable("userId") String userId
+    ) {
+        return BlogIdsQueryResponse.builder()
+                .blogIds(useCase.findBlogIdsByUserId(userId))
+                .build();
+    }
+}

--- a/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/dto/BlogInternalQueryDto.java
+++ b/services/blog/driving/web-mvc/src/main/java/nettee/blolet/blog/web/admin/dto/BlogInternalQueryDto.java
@@ -1,0 +1,15 @@
+package nettee.blolet.blog.web.admin.dto;
+
+import lombok.Builder;
+
+import java.util.Set;
+
+public final class BlogInternalQueryDto {
+
+    private BlogInternalQueryDto() {}
+
+    @Builder
+    public record BlogIdsQueryResponse(
+            Set<String> blogIds
+    ) {}
+}

--- a/services/blog/export/client-api/src/main/java/nettee/blolet/blog/export/client/api/BlogClient.java
+++ b/services/blog/export/client-api/src/main/java/nettee/blolet/blog/export/client/api/BlogClient.java
@@ -1,14 +1,17 @@
 package nettee.blolet.blog.export.client.api;
 
+import nettee.blolet.blog.export.client.api.BlogClientDto.BlogIdsQueryResponse;
 import nettee.blolet.blog.export.client.api.BlogClientDto.BlogInternalCreateCommand;
 import nettee.blolet.blog.export.client.api.BlogClientDto.BlogCreateResponse;
 import nettee.blolet.blog.export.client.api.BlogClientDto.BlogOwnershipVerifyResponse;
 
 public interface BlogClient {
+    BlogCreateResponse create(BlogInternalCreateCommand dto);
+
+    BlogIdsQueryResponse getBlogIdsByUserId(String userId);
+
     BlogOwnershipVerifyResponse verifyOwnership(String userId, String blogId);
     BlogOwnershipVerifyResponse verifyOwnershipFresh(String userId, String blogId);
     BlogOwnershipVerifyResponse verifyOwnershipByProfileId(String profileId, String blogId);
     BlogOwnershipVerifyResponse verifyOwnershipByProfileIdFresh(String profileId, String blogId);
-
-    BlogCreateResponse create(BlogInternalCreateCommand dto);
 }

--- a/services/blog/export/client-api/src/main/java/nettee/blolet/blog/export/client/api/BlogClientDto.java
+++ b/services/blog/export/client-api/src/main/java/nettee/blolet/blog/export/client/api/BlogClientDto.java
@@ -3,6 +3,8 @@ package nettee.blolet.blog.export.client.api;
 import lombok.Builder;
 import nettee.blolet.blog.readmodel.BlogReadModels.BlogDetail;
 
+import java.util.Set;
+
 import static nettee.blolet.blog.api.validation.BlogValidator.BlogValidationTarget.BLOG_NAME;
 import static nettee.blolet.blog.api.validation.BlogValidator.BlogValidationTarget.BLOG_NICKNAME;
 import static nettee.blolet.blog.api.validation.BlogValidator.BlogValidationTarget.BLOG_PROFILE_ID;
@@ -37,6 +39,11 @@ public final class BlogClientDto {
     @Builder
     public record BlogCreateResponse(
             BlogDetail blog
+    ) {}
+
+    @Builder
+    public record BlogIdsQueryResponse(
+            Set<String> blogIds
     ) {}
 
     @Builder

--- a/services/blog/export/client-webmvc/src/main/java/nettee/blolet/blog/export/client/webmvc/RestBlogClient.java
+++ b/services/blog/export/client-webmvc/src/main/java/nettee/blolet/blog/export/client/webmvc/RestBlogClient.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import nettee.blolet.blog.export.client.api.BlogClient;
 import nettee.blolet.blog.export.client.api.BlogClientDto.BlogCreateResponse;
+import nettee.blolet.blog.export.client.api.BlogClientDto.BlogIdsQueryResponse;
 import nettee.blolet.blog.export.client.api.BlogClientDto.BlogInternalCreateCommand;
 import nettee.blolet.blog.export.client.api.BlogClientDto.BlogOwnershipVerifyResponse;
 import nettee.client.request.NetteeRequest;
@@ -20,6 +21,24 @@ public final class RestBlogClient implements BlogClient {
     public RestBlogClient(NetteeClient customClient) {
         this.customClient = customClient;
         this.cacheMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     *
+     * @param dto Request body
+     * @return BlogCreateResponse { "blog" : {...} }
+     */
+    @Override
+    public BlogCreateResponse create(BlogInternalCreateCommand dto) {
+        var request = generateBlogCreateRequest(dto);
+
+        return customClient.post(request);
+    }
+
+    @Override
+    public BlogIdsQueryResponse getBlogIdsByUserId(String userId) {
+        var request = generateBlogIdQueryRequest(userId);
+        return customClient.get(request);
     }
 
     /**
@@ -112,18 +131,6 @@ public final class RestBlogClient implements BlogClient {
         return response;
     }
 
-    /**
-     *
-     * @param dto Request body
-     * @return BlogCreateResponse { "blog" : {...} }
-     */
-    @Override
-    public BlogCreateResponse create(BlogInternalCreateCommand dto) {
-        var request = generateBlogCreateRequest(dto);
-
-        return customClient.post(request);
-    }
-
     private Cache<Object, Object> createCacheStorage(BlogRequestType type) {
         return Caffeine.newBuilder()
                 .expireAfterAccess(6000, TimeUnit.SECONDS)
@@ -155,7 +162,15 @@ public final class RestBlogClient implements BlogClient {
                 .path("/internal/blogs")
                 .responseType(BlogCreateResponse.class)
                 .build();
+    }
 
+    private NetteeRequest<BlogIdsQueryResponse> generateBlogIdQueryRequest(String userId) {
+        return NetteeRequest.<BlogIdsQueryResponse>builder()
+                .domain("blog")
+                .path("/internal/users/{userId}/blog-id")
+                .uriVariables(new Object[] { userId })
+                .responseType(BlogIdsQueryResponse.class)
+                .build();
     }
 
     private enum BlogRequestType {


### PR DESCRIPTION
<br /><br />

<table border="3" align="center">
<tr height="45">
  <td width="45" align="center">🤖</td>
  <td align="center"><strong>이 문서는 인공지능으로 작성하였습니다.</strong></td>
</tr>
</table>

<br />

## Issues

- Resolves #409
  - Resolves #410
  - Resolves #411

## Description

- 블로그 소유 관계 조회를 위해 **사용자 ID 기준 블로그 ID 집합을 반환하는 내부 API**를 추가했습니다.
  - **WebMVC**: `GET /internal/users/{userId}/blog-id` 엔드포인트 및 컨트롤러 추가(응답 DTO `BlogIdsQueryResponse`). :contentReference[oaicite:0]{index=0}
  - **Application**: `BlogReadUseCase`/Query 서비스에 `findBlogIdsByUserId(String userId)`를 도입했습니다. :contentReference[oaicite:1]{index=1}
  - **Persistence (RDB)**:
    - Projection `BlogIdProjection(Long id)` 추가
    - `BlogQueryJpaRepository#findBlogIdByUserId(Long userId)` 및 어댑터 구현(문자열로 변환해 Set 반환) :contentReference[oaicite:2]{index=2}
  - **Client**:
    - `BlogClient#getBlogIdsByUserId(String userId)` 및 응답 DTO 도입
    - WebMVC REST 클라이언트에서 `/internal/users/{userId}/blog-id` 호출 구현 :contentReference[oaicite:3]{index=3}
- 응답 스키마 예시
  ```json
  {
    "blogIds": ["123", "456"]
  }
  ```

<br />

## Review Points

- **API 네이밍**: 경로는 단수(`/blog-id`)지만 응답은 다수(Set)입니다. 경로를 `/blog-ids`로 변경할지, 그대로 둘지 합의가 필요합니다. (응답 DTO는 `BlogIdsQueryResponse`로 복수형)
- **검증/에러 처리**: `userId`는 컨트롤러에서 문자열로 받고, RDB 어댑터에서 `Long.valueOf` 변환합니다. 숫자가 아닐 경우 처리(400 변환 등) 규칙 확인/보완 부탁드립니다. :contentReference[oaicite:4]{index=4}
- **권한/가시성**: 내부용 `/internal/**` 엔드포인트로 노출됩니다. 게이트웨이/필터 레벨 접근 제어가 기대대로 동작하는지 확인 부탁드립니다.
- **성능**: `blog.user_id`에 대한 인덱스 존재 여부 확인(대량 트래픽 대비). Projection 기반 조회로 N+1은 없음. :contentReference[oaicite:5]{index=5}
- **트랜잭션**: Query 서비스/UseCase 메서드의 `@Transactional(readOnly = true)` 적용 여부 확인. :contentReference[oaicite:6]{index=6}
- **클라이언트 캐싱**: `RestBlogClient`에는 캐싱 로직이 일부 존재하나 본 메서드에는 미적용입니다. 호출 빈도에 따라 캐시(예: 5–10분) 적용 고려 바랍니다. :contentReference[oaicite:7]{index=7}

<br />
<table border="1" align="center">
<tr>
  <td>
  
  [**리뷰하러 가기**](./412/files)
  
  </td>
</tr>
</table>

<br />

## How Has This Been Tested?

- 실행하여 육안으로 확인하였습니다.
- 환경: 로컬 Docker(PostgreSQL/Redis) + Spring Boot 로컬 프로필
- 수동 점검 시나리오
  - 존재하는 사용자 ID로 호출 시 `blogIds`가 비어 있지 않은지 확인
  - 블로그가 없는 사용자 ID로 호출 시 `blogIds: []` 확인
  - 숫자가 아닌 `userId` 전달 시 에러 응답 규격 확인
- AI 제안
  - **WebMVC 슬라이스 테스트(@WebMvcTest)**: `/internal/users/{userId}/blog-id` 200/400 케이스, 응답 스키마 검증
  - **어댑터 단위 테스트(@DataJpaTest)**: `findBlogIdByUserId`가 기대 ID 집합을 반환하는지, 빈 결과 반환 케이스
  - **어플리케이션 서비스 테스트**: `findBlogIdsByUserId`가 Port 호출 및 변환을 위임/조합하는지 확인
  - **클라이언트 통합 테스트**: `RestBlogClient#getBlogIdsByUserId`가 올바른 경로(`/internal/users/{userId}/blog-id`)로 요청하고 DTO 매핑되는지 (MockWebServer 등)

<br />

## Additional Notes

- 비교 링크(변경 사항 참고): https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/blog-client-query-blog-id
- 이 PR은 **기존 퍼블릭 API 변경 없이 내부 조회 기능을 추가**합니다.
- ID 타입: RDB Projection은 `Long`, 외부 노출/클라이언트는 `String`으로 통일했습니다(문자열 일관성 유지 목적). :contentReference[oaicite:8]{index=8}

