### PR TITLE
Series: 시리즈 상세 조회(단건 조회) 시 소유자 여부에 따라 동작을 구분합니다.

### DIFF
--- a/services/series/application/build.gradle.kts
+++ b/services/series/application/build.gradle.kts
@@ -1,5 +1,7 @@
 val seriesApi: String by project
+val blogClientWebMvc: String by project
 
 dependencies {
     api(project(seriesApi))
+    api(project(blogClientWebMvc))
 }

--- a/services/series/application/src/main/java/nettee/series/application/port/SeriesQueryRepositoryPort.java
+++ b/services/series/application/src/main/java/nettee/series/application/port/SeriesQueryRepositoryPort.java
@@ -8,7 +8,8 @@ import java.util.Optional;
 
 public interface SeriesQueryRepositoryPort {
     
-    
     Optional<SeriesDetail> findBySeriesIdAndOwnership(String seriesId, String userBlogId);
+    Optional<SeriesDetail> findExceptDraftsById(String seriesId);
+
     List<SeriesSummary> findAllByBlogId(String blogId);
 }

--- a/services/series/application/src/main/java/nettee/series/application/port/SeriesQueryRepositoryPort.java
+++ b/services/series/application/src/main/java/nettee/series/application/port/SeriesQueryRepositoryPort.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface SeriesQueryRepositoryPort {
     
-    Optional<SeriesDetail> findBySeriesId(String seriesId);
     
+    Optional<SeriesDetail> findBySeriesIdAndOwnership(String seriesId, String userBlogId);
     List<SeriesSummary> findAllByBlogId(String blogId);
 }

--- a/services/series/application/src/main/java/nettee/series/application/port/SeriesQueryRepositoryPort.java
+++ b/services/series/application/src/main/java/nettee/series/application/port/SeriesQueryRepositoryPort.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface SeriesQueryRepositoryPort {
     
-    Optional<SeriesDetail> findBySeriesIdAndOwnership(String seriesId, String userBlogId);
+    Optional<SeriesDetail> findByIdAndOwnership(String seriesId, String userBlogId);
     Optional<SeriesDetail> findExceptDraftsById(String seriesId);
 
     List<SeriesSummary> findAllByBlogId(String blogId);

--- a/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
+++ b/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
@@ -23,7 +23,7 @@ public class SeriesQueryService implements SeriesReadUseCase, SeriesVisitUseCase
     private final BlogClient blogClient;
     
     @Override
-    public SeriesDetail getSeriesByOwnership(String seriesId, String userId) {
+    public SeriesDetail findDetailForOwner(String seriesId, String userId) {
         assert seriesId != null;
         assert userId != null;
 

--- a/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
+++ b/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
@@ -1,6 +1,7 @@
 package nettee.series.application.services;
 
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.blog.export.client.api.BlogClient;
 import nettee.series.application.port.SeriesQueryRepositoryPort;
 import nettee.series.application.usecase.SeriesReadUseCase;
 import nettee.series.application.usecase.SeriesVisitUseCase;
@@ -9,7 +10,9 @@ import nettee.series.readmodel.SeriesQueryModels.SeriesSummary;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
+import static nettee.blolet.blog.exception.BlogErrorCode.BLOG_NOT_IMPLEMENTED_FEATURE;
 import static nettee.series.exception.SeriesErrorCode.SERIES_NOT_FOUND;
 
 @Service
@@ -17,15 +20,23 @@ import static nettee.series.exception.SeriesErrorCode.SERIES_NOT_FOUND;
 public class SeriesQueryService implements SeriesReadUseCase, SeriesVisitUseCase {
     
     private final SeriesQueryRepositoryPort queryRepositoryPort;
+    private final BlogClient blogClient;
     
     @Override
-    public SeriesDetail getSeries(String seriesId) {
+    public SeriesDetail getSeriesByOwnership(String seriesId, String userId) {
         assert seriesId != null;
+        assert userId != null;
 
-        return queryRepositoryPort.findBySeriesId(seriesId)
+        Set<String> blogIds = blogClient.getBlogIdsByUserId(userId)
+                .blogIds();
+        if (blogIds.size() != 1) throw BLOG_NOT_IMPLEMENTED_FEATURE.exception();
+
+        String userBlogId = blogIds.iterator().next();
+
+        return queryRepositoryPort.findByIdAndOwnership(seriesId, userBlogId)
                 .orElseThrow(SERIES_NOT_FOUND::exception);
     }
-    
+
     @Override
     public List<SeriesSummary> getSeriesList(String blogId) {
         assert blogId != null;
@@ -35,7 +46,7 @@ public class SeriesQueryService implements SeriesReadUseCase, SeriesVisitUseCase
 
     @Override
     public SeriesDetail visitSeries(String seriesId) {
-        return queryRepositoryPort.findExceptDraftsBySeriesId(seriesId)
+        return queryRepositoryPort.findExceptDraftsById(seriesId)
                 .orElseThrow(SERIES_NOT_FOUND::exception);
     }
 }

--- a/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
+++ b/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
@@ -45,7 +45,7 @@ public class SeriesQueryService implements SeriesReadUseCase, SeriesVisitUseCase
     }
 
     @Override
-    public SeriesDetail visitSeries(String seriesId) {
+    public SeriesDetail findDetailForPublic(String seriesId) {
         return queryRepositoryPort.findExceptDraftsById(seriesId)
                 .orElseThrow(SERIES_NOT_FOUND::exception);
     }

--- a/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
+++ b/services/series/application/src/main/java/nettee/series/application/services/SeriesQueryService.java
@@ -3,6 +3,7 @@ package nettee.series.application.services;
 import lombok.RequiredArgsConstructor;
 import nettee.series.application.port.SeriesQueryRepositoryPort;
 import nettee.series.application.usecase.SeriesReadUseCase;
+import nettee.series.application.usecase.SeriesVisitUseCase;
 import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
 import nettee.series.readmodel.SeriesQueryModels.SeriesSummary;
 import org.springframework.stereotype.Service;
@@ -13,7 +14,7 @@ import static nettee.series.exception.SeriesErrorCode.SERIES_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
-public class SeriesQueryService implements SeriesReadUseCase {
+public class SeriesQueryService implements SeriesReadUseCase, SeriesVisitUseCase {
     
     private final SeriesQueryRepositoryPort queryRepositoryPort;
     
@@ -30,5 +31,11 @@ public class SeriesQueryService implements SeriesReadUseCase {
         assert blogId != null;
         
         return queryRepositoryPort.findAllByBlogId(blogId);
+    }
+
+    @Override
+    public SeriesDetail visitSeries(String seriesId) {
+        return queryRepositoryPort.findExceptDraftsBySeriesId(seriesId)
+                .orElseThrow(SERIES_NOT_FOUND::exception);
     }
 }

--- a/services/series/application/src/main/java/nettee/series/application/usecase/SeriesReadUseCase.java
+++ b/services/series/application/src/main/java/nettee/series/application/usecase/SeriesReadUseCase.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface SeriesReadUseCase {
     
-    SeriesDetail getSeriesByOwnership(String seriesId, String userId);
+    SeriesDetail findDetailForOwner(String seriesId, String userId);
 
     List<SeriesSummary> getSeriesList(String blogId);
 }

--- a/services/series/application/src/main/java/nettee/series/application/usecase/SeriesReadUseCase.java
+++ b/services/series/application/src/main/java/nettee/series/application/usecase/SeriesReadUseCase.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface SeriesReadUseCase {
     
-    SeriesDetail getSeries(String seriesId);
-    
+    SeriesDetail getSeriesByOwnership(String seriesId, String userId);
+
     List<SeriesSummary> getSeriesList(String blogId);
 }

--- a/services/series/application/src/main/java/nettee/series/application/usecase/SeriesVisitUseCase.java
+++ b/services/series/application/src/main/java/nettee/series/application/usecase/SeriesVisitUseCase.java
@@ -3,5 +3,5 @@ package nettee.series.application.usecase;
 import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
 
 public interface SeriesVisitUseCase {
-    SeriesDetail visitSeries(String seriesId);
+    SeriesDetail findDetailForPublic(String seriesId);
 }

--- a/services/series/application/src/main/java/nettee/series/application/usecase/SeriesVisitUseCase.java
+++ b/services/series/application/src/main/java/nettee/series/application/usecase/SeriesVisitUseCase.java
@@ -1,0 +1,7 @@
+package nettee.series.application.usecase;
+
+import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
+
+public interface SeriesVisitUseCase {
+    SeriesDetail visitSeries(String seriesId);
+}

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
@@ -35,11 +35,12 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
      * 트래픽 절감, 안정적인 성능, 높은 유지보수성을 위하여 '싱글쿼리(단일 쿼리)' 대신 '스플릿 쿼리(분할 쿼리)'를 사용합니다.
      *
      * @param seriesId
+     * @param userBlogId
      * @return
      */
     @Override
-    public Optional<SeriesDetail> findBySeriesId(String seriesId) {
-        Long longSeriesId = Long.parseLong(seriesId);
+    public Optional<SeriesDetail> findByIdAndOwnership(String seriesId, String userBlogId) {
+        long longSeriesId = Long.parseLong(seriesId);
 
         SeriesDetailProjection seriesDetail = getQuerydsl().createQuery()
                 .select(Projections.constructor(

--- a/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
+++ b/services/series/driven/rdb/src/main/java/nettee/series/driven/rdb/persistence/SeriesQueryAdapter.java
@@ -34,33 +34,20 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
     /**
      * 트래픽 절감, 안정적인 성능, 높은 유지보수성을 위하여 '싱글쿼리(단일 쿼리)' 대신 '스플릿 쿼리(분할 쿼리)'를 사용합니다.
      *
-     * @param seriesId
-     * @param userBlogId
-     * @return
+     * @param seriesId 시리즈 아이디
+     * @param userBlogId 로그인 사용자의 블로그 아이디(지금은 하나). 지금은 블로그 아이디로 소유권을 확인 중.
+     * @return Optional series detail model
      */
     @Override
     public Optional<SeriesDetail> findByIdAndOwnership(String seriesId, String userBlogId) {
         long longSeriesId = Long.parseLong(seriesId);
+        long longOwnerBlogId = Long.parseLong(userBlogId);
 
-        SeriesDetailProjection seriesDetail = getQuerydsl().createQuery()
-                .select(Projections.constructor(
-                        SeriesDetailProjection.class,
-                        seriesEntity.id,
-                        seriesEntity.blogId,
-                        seriesEntity.title,
-                        seriesEntity.description,
-                        seriesEntity.bannerUrl,
-                        seriesEntity.displayOrder,
-                        seriesEntity.createdAt,
-                        seriesEntity.updatedAt
-                ))
-                .from(seriesEntity)
-                .where(seriesEntity.id.eq(longSeriesId))
-                .fetchOne();
-
+        SeriesDetailProjection seriesDetail = querySeriesDetail(longSeriesId);
         if (seriesDetail == null) throw SERIES_NOT_FOUND.exception();
+        boolean isOwner = seriesDetail.blogId() == longOwnerBlogId;
 
-        List<SeriesArticleSummaryProjection> articles = getQuerydsl().createQuery()
+        var query = getQuerydsl().createQuery()
                 .select(Projections.constructor(
                         SeriesArticleSummaryProjection.class,
 //                        seriesArticleEntity.seriesId,
@@ -77,8 +64,53 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
                 ))
                 .from(seriesArticleEntity)
                 .leftJoin(articleEntity).on(seriesArticleEntity.articleId.eq(articleEntity.id))
-                .leftJoin(draftEntity).on(seriesArticleEntity.draftId.eq(draftEntity.id))
+//                .leftJoin(draftEntity)
+//                .on(
+//                        seriesArticleEntity.draftId.eq(draftEntity.id)
+////                                .and(draftEntity.articleId.isNull())
+//                )
                 .where(seriesArticleEntity.seriesId.eq(longSeriesId))
+                .orderBy(seriesArticleEntity.displayOrder.asc());
+
+        // 조건부로 draftEntity join 추가
+        if (isOwner) {
+            query.leftJoin(draftEntity)
+                    .on(
+                            seriesArticleEntity.draftId.eq(draftEntity.id)
+                                    .and(draftEntity.articleId.isNull())
+                    );
+        }
+
+        List<SeriesArticleSummaryProjection> articles = query.fetch();
+
+        return Optional.ofNullable(
+                mapper.toDetail(seriesDetail, articles)
+        );
+    }
+
+    @Override
+    public Optional<SeriesDetail> findExceptDraftsById(String seriesId) {
+        long longSeriesId = Long.parseLong(seriesId);
+
+        SeriesDetailProjection seriesDetail = querySeriesDetail(longSeriesId);
+        if (seriesDetail == null) throw SERIES_NOT_FOUND.exception();
+
+        List<SeriesArticleSummaryProjection> articles = getQuerydsl().createQuery()
+                .select(Projections.constructor(
+                        SeriesArticleSummaryProjection.class,
+                        seriesArticleEntity.articleId,
+                        seriesArticleEntity.draftId,
+                        articleEntity.title,
+                        seriesArticleEntity.displayOrder,
+                        seriesArticleEntity.createdAt,
+                        seriesArticleEntity.updatedAt
+                ))
+                .from(seriesArticleEntity)
+                .leftJoin(articleEntity).on(seriesArticleEntity.articleId.eq(articleEntity.id))
+                .where(
+                        seriesArticleEntity.seriesId.eq(longSeriesId)
+                                .and(seriesArticleEntity.articleId.isNotNull())
+                )
                 .orderBy(seriesArticleEntity.displayOrder.asc())
                 .fetch();
 
@@ -102,5 +134,23 @@ public class SeriesQueryAdapter extends QuerydslRepositorySupport implements Ser
                 .from(seriesEntity)
                 .where(seriesEntity.blogId.eq(Long.valueOf(blogId)))
                 .fetch();
+    }
+
+    private SeriesDetailProjection querySeriesDetail(long seriesId) {
+        return getQuerydsl().createQuery()
+                .select(Projections.constructor(
+                        SeriesDetailProjection.class,
+                        seriesEntity.id,
+                        seriesEntity.blogId,
+                        seriesEntity.title,
+                        seriesEntity.description,
+                        seriesEntity.bannerUrl,
+                        seriesEntity.displayOrder,
+                        seriesEntity.createdAt,
+                        seriesEntity.updatedAt
+                ))
+                .from(seriesEntity)
+                .where(seriesEntity.id.eq(seriesId))
+                .fetchOne();
     }
 }

--- a/services/series/driven/rdb/src/test/kotlin/nettee/series/driven/rdb/persistence/SeriesQueryAdapterTest.kt
+++ b/services/series/driven/rdb/src/test/kotlin/nettee/series/driven/rdb/persistence/SeriesQueryAdapterTest.kt
@@ -25,7 +25,7 @@ class SeriesQueryAdapterTest(
     val seriesId = 1L
 
     "[정상] findBySeriesId - 존재하는 경우" - {
-        val result = adapter.findBySeriesId(seriesId.toString())
+        val result = adapter.findByIdAndOwnership(seriesId.toString(), testBlogId.toString())
 
         "Optional 값이 존재해야 한다" {
             result.isPresent shouldBe true

--- a/services/series/driving/web-mvc/build.gradle.kts
+++ b/services/series/driving/web-mvc/build.gradle.kts
@@ -1,8 +1,10 @@
 val seriesApi: String by project
 val seriesApplication: String by project
+
 dependencies {
     api(project(seriesApi))
     api(project(seriesApplication))
+    compileOnly(project(":security-blolet-jwt-filter"))
 
     // validation
     compileOnly("jakarta.validation:jakarta.validation-api")

--- a/services/series/driving/web-mvc/build.gradle.kts
+++ b/services/series/driving/web-mvc/build.gradle.kts
@@ -20,5 +20,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-validation")
+    testImplementation(project(":security-blolet-jwt-filter"))
 }
 

--- a/services/series/driving/web-mvc/src/main/java/nettee/series/driving/web/SeriesQueryApi.java
+++ b/services/series/driving/web-mvc/src/main/java/nettee/series/driving/web/SeriesQueryApi.java
@@ -50,7 +50,7 @@ public class SeriesQueryApi {
         AtomicReference<SeriesDetail> series = new AtomicReference<>();
 
         signedUser.ifPresentOrElse(
-                (user) -> series.set(seriesReadUseCase.getSeriesByOwnership(seriesId, user.userId())),
+                (user) -> series.set(seriesReadUseCase.findDetailForOwner(seriesId, user.userId())),
                 () -> series.set(visitUseCase.visitSeries(seriesId))
         );
 

--- a/services/series/driving/web-mvc/src/main/java/nettee/series/driving/web/SeriesQueryApi.java
+++ b/services/series/driving/web-mvc/src/main/java/nettee/series/driving/web/SeriesQueryApi.java
@@ -51,7 +51,7 @@ public class SeriesQueryApi {
 
         signedUser.ifPresentOrElse(
                 (user) -> series.set(seriesReadUseCase.findDetailForOwner(seriesId, user.userId())),
-                () -> series.set(visitUseCase.visitSeries(seriesId))
+                () -> series.set(visitUseCase.findDetailForPublic(seriesId))
         );
 
         return SeriesDetailResponse.builder()

--- a/services/series/driving/web-mvc/src/main/java/nettee/series/driving/web/SeriesQueryApi.java
+++ b/services/series/driving/web-mvc/src/main/java/nettee/series/driving/web/SeriesQueryApi.java
@@ -6,12 +6,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import nettee.blolet.jwt.filter.annotation.AuthUser;
+import nettee.blolet.jwt.filter.annotation.AuthorizedUser;
 import nettee.series.application.usecase.SeriesReadUseCase;
+import nettee.series.application.usecase.SeriesVisitUseCase;
 import nettee.series.driving.web.dto.SeriesQueryDto.SeriesDetailResponse;
 import nettee.series.driving.web.dto.SeriesQueryDto.SeriesSummaryResponse;
+import nettee.series.readmodel.SeriesQueryModels.SeriesDetail;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SeriesQueryApi {
 
     private final SeriesReadUseCase seriesReadUseCase;
+    private final SeriesVisitUseCase visitUseCase;
 
     @Operation(summary = "시리즈 목록 조회", description = "블로그 ID를 기준으로 시리즈 목록을 조회합니다.")
     @ApiResponse(
@@ -35,9 +43,19 @@ public class SeriesQueryApi {
 
     @Operation(summary = "시리즈 상세 조회", description = "시리즈 ID를 이용해 시리즈를 상세 조회합니다.")
     @GetMapping("/series/{seriesId}")
-    public SeriesDetailResponse getSeries(@PathVariable("seriesId") String seriesId) {
+    public SeriesDetailResponse getSeries(
+            @PathVariable("seriesId") String seriesId,
+            @AuthUser Optional<AuthorizedUser> signedUser
+    ) {
+        AtomicReference<SeriesDetail> series = new AtomicReference<>();
+
+        signedUser.ifPresentOrElse(
+                (user) -> series.set(seriesReadUseCase.getSeriesByOwnership(seriesId, user.userId())),
+                () -> series.set(visitUseCase.visitSeries(seriesId))
+        );
+
         return SeriesDetailResponse.builder()
-                .series(seriesReadUseCase.getSeries(seriesId))
+                .series(series.get())
                 .build();
     }
 }


### PR DESCRIPTION

<br /><br />

<table border="3" align="center">
<tr height="45">
  <td width="45" align="center">🤖</td>
  <td align="center"><strong>이 문서는 인공지능으로 작성하였습니다.</strong></td>
</tr>
</table>

<br />

## Issues

- Resolves #385 
  - Resolves #388 
  - Resolves #389 
  - Resolves #390 
  - Resolves #415

## Description

- 로그인된 사용자의 **자원 소유권(ownership)** 에 따라 *시리즈 상세 조회* 분기 로직을 도입하였습니다.
  - **소유자(Owner)**: 비공개·임시(초안 포함) 콘텐츠까지 조회 가능한 경로
  - **비소유자(Authenticated/Anonymous)**: 퍼블리시된 아티클만 노출
- `SeriesQueryApi` 및 해당 유스케이스 계층에서 **소유권 기반 분기 메서드**로 구조화했습니다. (예: `findDetailForOwner(...)`, `findDetailForPublic(...)`)
- `QueryDSL` 조인 조건을 재정의하여 **아티클이 존재하면 드래프트가 중복 노출되지 않도록** 했습니다.
  - `leftJoin(draft).on(seriesArticle.draftId.eq(draft.id).and(article.id.isNull()))` 형태로 조건부 조인
  - 선택 컬럼은 `coalesce(article.title, draft.title)` 등으로 단일 소스 선택
- 인증 컨텍스트 주입부 개선: 컨트롤러 단에서 `@AuthUser Optional<AuthorizedUser>` 사용 시 **빈(Optional.empty) 주입 시나리오** 포함하여 처리 경로 보강
- 관련 이슈: #385

<br />

## Review Points

- **분기 정확성**: Owner와 Public 경로 간 데이터 차등(비공개 노출 방지, 소유자에겐 초안/보류 상태 포함)이 명확한지
- **조인 조건**: 아티클 존재 시 드래프트가 중복으로 나오지 않도록 `ON` 절 조건(`article.id.isNull()`)이 올바르게 적용되었는지
- **성능**: 시리즈 아티클 대량일 때 N+1 또는 중복 로딩 발생 여부(필요 시 `fetchJoin`/전용 조회 DTO 최적화)
- **정렬 일관성**: `displayOrder`, 생성/수정일 정렬 기준이 케이스별로 동일하게 유지되는지
- **API 스펙**: 응답 모델(초안 필드 노출 여부, 상태값, 권한 플래그 등) 변화가 있다면 Swagger 문서 반영 여부
- **에지 케이스**: 로그인했으나 프로필/블로그 매핑이 없는 사용자, 시리즈에 일부만 퍼블리시된 항목 혼재 시 동작

<br />
<table border="1" align="center">
<tr>
  <td>
  
  [**리뷰하러 가기**](./416/files)
  
  </td>
</tr>
</table>

<br />

## How Has This Been Tested?

- 로컬 환경(`local` 프로파일) + 더미 데이터 기반으로 시나리오별 수동 검증
  - **소유자 토큰**으로 조회 시: 초안/보류/발행 항목이 정책에 맞게 노출되는지 확인
  - **비소유자/비로그인**: 발행 아티클만 노출되는지 확인
  - 아티클과 드래프트가 모두 연결된 항목에서 **중복 노출 방지** 확인
- Postman으로 엔드포인트 호출, 응답 필드(타이틀/ID/정렬순서) 확인
- 실행하여 육안으로 확인하였습니다.
- AI 제안
  - WebMvcTest로 **소유자/비소유자/비로그인** 3케이스 스냅샷 테스트 추가
  - `QueryDSL` 쿼리 레벨 단위 테스트: 조인 조건(`article.id.isNull()`) 적용 시 레코드 수 검증
  - 대량 데이터에서의 성능 회귀 테스트 및 인덱스 점검(`series_article(series_id, display_order)`, `article(id, status)` 등)
  - Swagger 문서에 **권한별 응답 차이**를 명시

<br />

## Additional Notes

- 비교용: [develop...feature/series-query-detail-split-by-ownership](https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/series-query-detail-split-by-ownership)
- 후속 작업(제안)
  - 권한 플래그(예: `canEdit`, `canViewDraft`)를 응답에 포함하여 프론트 분기 단순화
  - 소유권 판별 로직을 별도 컴포넌트로 분리해 재사용성 확보(시리즈 외 다른 도메인에도 적용 가능)

