### PR TITLE
Auth: 비밀번호 변경

### DIFF
--- a/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
+++ b/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
@@ -27,6 +27,7 @@ public enum AuthErrorCode implements ErrorCode {
     AUTH_OTP_DESERIALIZE_FAILED("OTP 역직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AUTH_PASSWORD_RESET_INVALID("유효하지 않은 비밀번호 변경 요청입니다.", HttpStatus.UNAUTHORIZED),
     AUTH_REFRESH_TOKEN_NOT_FOUND("리프레시 토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    AUTH_PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     // rdb 관련 오류
     AUTH_USER_STATUS_INVALID("유효하지 않는 유저 상태입니다.", HttpStatus.BAD_REQUEST),

--- a/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
+++ b/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
@@ -27,7 +27,7 @@ public enum AuthErrorCode implements ErrorCode {
     AUTH_OTP_DESERIALIZE_FAILED("OTP 역직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AUTH_PASSWORD_RESET_INVALID("유효하지 않은 비밀번호 변경 요청입니다.", HttpStatus.UNAUTHORIZED),
     AUTH_REFRESH_TOKEN_NOT_FOUND("리프레시 토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    AUTH_PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    AUTH_PASSWORD_MISMATCHED("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     // rdb 관련 오류
     AUTH_USER_STATUS_INVALID("유효하지 않는 유저 상태입니다.", HttpStatus.BAD_REQUEST),

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthCommandRepositoryPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthCommandRepositoryPort.java
@@ -1,5 +1,7 @@
 package nettee.auth.port;
 
+import java.lang.ScopedValue;
+import java.util.Optional;
 import nettee.auth.domain.User;
 
 public interface AuthCommandRepositoryPort {
@@ -9,4 +11,8 @@ public interface AuthCommandRepositoryPort {
     void deleteById(String userId);
 
     void updatePassword(User user);
+
+    // 데이터 정합성이 중요한 경우에 사용
+    Optional<User> findById(String userId);
+    Optional<User> findByEmail(String email);
 }

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthQueryRepositoryPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthQueryRepositoryPort.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import nettee.auth.domain.User;
 
 public interface AuthQueryRepositoryPort {
+    Optional<User> findById(String userId);
     Optional<User> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
 

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthQueryRepositoryPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthQueryRepositoryPort.java
@@ -4,9 +4,6 @@ import java.util.Optional;
 import nettee.auth.domain.User;
 
 public interface AuthQueryRepositoryPort {
-    Optional<User> findById(String userId);
     Optional<User> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
-
-    Optional<User> findByEmail(String email);
 }

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -7,6 +7,7 @@ import static nettee.auth.exception.AuthErrorCode.AUTH_ACCOUNT_NOT_FOUND;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_DESERIALIZE_FAILED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_INVALID;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_SERIALIZE_FAILED;
+import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_NOT_MATCH;
 import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_RESET_INVALID;
 import static nettee.auth.exception.AuthErrorCode.AUTH_REFRESH_TOKEN_NOT_FOUND;
 
@@ -241,6 +242,47 @@ public class AuthCommandService implements AuthSignUsecase {
 
         // nonce 삭제
         authRedisPort.delete("password-reset:" + email);
+    }
+
+    @Override
+    public String verifyPassword(String userId, String password) {
+        // 비밀번호 조회를 위한 사용자 조회
+        User userEntity = authQueryRepositoryPort.findById(userId)
+                .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(password, userEntity.getEncodedPassword())) {
+            throw new AuthException(AUTH_PASSWORD_NOT_MATCH);
+        }
+
+        // nonce 생성 및 redis 저장
+        String nonce = generateSecureRandom();
+        authRedisPort.save("password-change:" + userId, nonce, Duration.ofMinutes(PASSWORD_RESET_URL_EXPIRATION));
+
+        return nonce;
+    }
+
+    @Override
+    public void changePassword(String userId, String newPassword, String nonce) {
+        // 비밀번호 변경을 위한 사용자 조회
+        User userEntity = authQueryRepositoryPort.findById(userId)
+                .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
+
+        // nonce 조회 및 검증
+        String storedNonce = authRedisPort.get("password-change:" + userId);
+        if (!nonce.equals(storedNonce)) {
+            throw new AuthException(AUTH_PASSWORD_RESET_INVALID);
+        }
+
+        // 새로운 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(newPassword);
+
+        // 비밀번호 변경
+        userEntity.setEncodedPassword(encodedPassword);
+        authCommandRepositoryPort.updatePassword(userEntity);
+
+        // nonce 삭제
+        authRedisPort.delete("password-change:" + userId);
     }
 
     @Override

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -7,7 +7,7 @@ import static nettee.auth.exception.AuthErrorCode.AUTH_ACCOUNT_NOT_FOUND;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_DESERIALIZE_FAILED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_INVALID;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_SERIALIZE_FAILED;
-import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_NOT_MATCH;
+import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_MISMATCHED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_RESET_INVALID;
 import static nettee.auth.exception.AuthErrorCode.AUTH_REFRESH_TOKEN_NOT_FOUND;
 
@@ -207,7 +207,7 @@ public class AuthCommandService implements AuthSignUsecase {
     @Override
     public void sendPasswordResetEmail(String email) {
         // 사용자 존재 여부 확인
-        authQueryRepositoryPort.findByEmail(email)
+        authCommandRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
 
         // nonce 생성
@@ -224,7 +224,7 @@ public class AuthCommandService implements AuthSignUsecase {
     @Override
     public void resetPassword(String email, String newPassword, String nonce) {
         // 사용자 존재 여부 확인
-        User user = authQueryRepositoryPort.findByEmail(email)
+        User user = authCommandRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
 
         // nonce 조회 및 검증
@@ -247,12 +247,12 @@ public class AuthCommandService implements AuthSignUsecase {
     @Override
     public String verifyPassword(String userId, String password) {
         // 비밀번호 조회를 위한 사용자 조회
-        User userEntity = authQueryRepositoryPort.findById(userId)
+        User userEntity = authCommandRepositoryPort.findById(userId)
                 .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
 
         // 비밀번호 검증
         if (!passwordEncoder.matches(password, userEntity.getEncodedPassword())) {
-            throw new AuthException(AUTH_PASSWORD_NOT_MATCH);
+            throw new AuthException(AUTH_PASSWORD_MISMATCHED);
         }
 
         // nonce 생성 및 redis 저장
@@ -265,7 +265,7 @@ public class AuthCommandService implements AuthSignUsecase {
     @Override
     public void changePassword(String userId, String newPassword, String nonce) {
         // 비밀번호 변경을 위한 사용자 조회
-        User userEntity = authQueryRepositoryPort.findById(userId)
+        User userEntity = authCommandRepositoryPort.findById(userId)
                 .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_NOT_FOUND));
 
         // nonce 조회 및 검증

--- a/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
+++ b/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
@@ -15,6 +15,8 @@ public interface AuthSignUsecase {
 
     void sendPasswordResetEmail(String email);
     void resetPassword(String email, String newPassword, String nonce);
+    String verifyPassword(String userId, String password);
+    void changePassword(String userId, String password, String nonce);
 
     LoginTokenModel refreshAccessToken(String userId, String refreshToken);
 }

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthCommandRepositoryAdapter.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthCommandRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package nettee.auth.rdb.adapter;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import nettee.auth.domain.User;
 import nettee.auth.port.AuthCommandRepositoryPort;
@@ -37,5 +38,17 @@ public class AuthCommandRepositoryAdapter implements AuthCommandRepositoryPort {
     public void updatePassword(User user) {
         UserEntity entity = mapper.toEntity(user);
         authJpaRepository.save(entity);
+    }
+
+    @Override
+    public Optional<User> findById(String userId) {
+        Optional<UserEntity> userEntity = authJpaRepository.findById(Long.valueOf(userId));
+        return userEntity.map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        Optional<UserEntity> userEntity = authJpaRepository.findByEmail(email);
+        return userEntity.map(mapper::toDomain);
     }
 }

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthQueryRepositoryAdapter.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthQueryRepositoryAdapter.java
@@ -17,6 +17,12 @@ public class AuthQueryRepositoryAdapter implements AuthQueryRepositoryPort {
     private final UserEntityMapper mapper;
 
     @Override
+    public Optional<User> findById(String userId) {
+        Optional<UserEntity> userEntity = authJpaRepository.findById(Long.valueOf(userId));
+        return userEntity.map(mapper::toDomain);
+    }
+
+    @Override
     public Optional<User> findByLoginId(String loginId) {
         Optional<UserEntity> userEntity = authJpaRepository.findByLoginId(loginId);
         return userEntity.map(mapper::toDomain);

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthQueryRepositoryAdapter.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthQueryRepositoryAdapter.java
@@ -17,12 +17,6 @@ public class AuthQueryRepositoryAdapter implements AuthQueryRepositoryPort {
     private final UserEntityMapper mapper;
 
     @Override
-    public Optional<User> findById(String userId) {
-        Optional<UserEntity> userEntity = authJpaRepository.findById(Long.valueOf(userId));
-        return userEntity.map(mapper::toDomain);
-    }
-
-    @Override
     public Optional<User> findByLoginId(String loginId) {
         Optional<UserEntity> userEntity = authJpaRepository.findByLoginId(loginId);
         return userEntity.map(mapper::toDomain);
@@ -31,11 +25,5 @@ public class AuthQueryRepositoryAdapter implements AuthQueryRepositoryPort {
     @Override
     public boolean existsByLoginId(String loginId) {
         return authJpaRepository.existsByLoginId(loginId);
-    }
-
-    @Override
-    public Optional<User> findByEmail(String email) {
-        Optional<UserEntity> userEntity = authJpaRepository.findByEmail(email);
-        return userEntity.map(mapper::toDomain);
     }
 }

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -9,8 +9,10 @@ import nettee.auth.web.dto.AuthCommandDto.EmailVerifyRequest;
 import nettee.auth.web.dto.AuthCommandDto.EmailVerifySendRequest;
 import nettee.auth.web.dto.AuthCommandDto.LoginRequest;
 import nettee.auth.web.dto.AuthCommandDto.LoginResponse;
+import nettee.auth.web.dto.AuthCommandDto.PasswordChangeRequest;
 import nettee.auth.web.dto.AuthCommandDto.PasswordForgotRequest;
 import nettee.auth.web.dto.AuthCommandDto.PasswordResetRequest;
+import nettee.auth.web.dto.AuthCommandDto.PasswordVerifyRequest;
 import nettee.auth.web.dto.AuthCommandDto.SignUpRequest;
 import nettee.auth.web.mapper.AuthDtoMapper;
 import nettee.blolet.auth.readmodel.AuthCommandModels.LoginTokenModel;
@@ -148,6 +150,31 @@ public class AuthCommandApi {
     public void resetPassword(@RequestParam String nonce,
                               @RequestBody PasswordResetRequest request) {
         authSignUsecase.resetPassword(request.email(), request.newPassword(), nonce);
+    }
+
+    // TODO: 마이페이지 정보 수정 전, 비밀번호 재인증 API로 활용 가능
+    @PostMapping("/password/verify")
+    @Operation(
+            summary = "비밀번호 변경 전 재인증",
+            description = "사용자가 비밀번호 변경 전, 본인 확인을 위해 비밀번호를 재인증합니다."
+    )
+    public ResponseEntity<String> verifyPassword(@AuthUser AuthorizedUser authorizedUser,
+                                                 @RequestBody PasswordVerifyRequest passwordVerifyRequest) {
+        String userId = authorizedUser.userId();
+        String nonce = authSignUsecase.verifyPassword(userId, passwordVerifyRequest.password());
+        return ResponseEntity.ok(nonce);
+    }
+
+    @PostMapping("/password/change")
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "사용자가 비밀번호를 변경합니다."
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void verifyPassword(@AuthUser AuthorizedUser authorizedUser,
+                               @RequestBody PasswordChangeRequest passwordChangeRequest) {
+        String userId = authorizedUser.userId();
+        authSignUsecase.changePassword(userId, passwordChangeRequest.password(), passwordChangeRequest.nonce());
     }
 
     @PostMapping("/token/refresh")

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -135,7 +135,7 @@ public class AuthCommandApi {
             description = "사용자의 이메일로 비밀번호를 변경할 수 있는 링크를 발송합니다."
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public ResponseEntity<String> sendPasswordResetEmail(@RequestBody PasswordForgotRequest request) {
+    public void sendPasswordResetEmail(@RequestBody PasswordForgotRequest request) {
         authSignUsecase.sendPasswordResetEmail(request.email());
     }
 

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -131,7 +131,7 @@ public class AuthCommandApi {
         return ResponseEntity.ok(token);
     }
 
-    @PostMapping("email/password/reset/send")
+    @PostMapping("/email/password/reset/send")
     @Operation(
             summary = "이메일 비밀번호 재설정 링크 전송",
             description = "사용자의 이메일로 비밀번호를 변경할 수 있는 링크를 발송합니다."
@@ -141,7 +141,7 @@ public class AuthCommandApi {
         authSignUsecase.sendPasswordResetEmail(request.email());
     }
 
-    @PostMapping("email/password/reset")
+    @PostMapping("/email/password/reset")
     @Operation(
             summary = "이메일 비밀번호 재설정",
             description = "사용자가 이메일 링크를 통해 비밀번호를 변경합니다."

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
@@ -139,6 +139,38 @@ public final class AuthCommandDto {
             validateRegex(newPassword, PASSWORD_REGEX, AUTH_PASSWORD_INVALID_FORMAT);
         }
     }
+    
+    @Schema(description = "비밀번호 변경 전 재인증")
+    public record PasswordVerifyRequest(
+            @Schema(description = "기존 비밀번호", example = "Blolet1225!")
+            String password
+    ) {
+        public PasswordVerifyRequest {
+            validateNotBlank(password, AUTH_PASSWORD_REQUIRED);
+            password = password.strip();
+
+            // 비밀번호 정규식 검증
+            final String PASSWORD_REGEX = "^[A-Za-z\\d!\"#$%&'()*+,\\-./:;<=>?@\\[\\]^_`{|}~]+$";
+            validateRegex(password, PASSWORD_REGEX, AUTH_PASSWORD_INVALID_FORMAT);
+        }
+    }
+
+    @Schema(description = "비밀번호 변경")
+    public record PasswordChangeRequest(
+            @Schema(description = "새로운 비밀번호", example = "NewBlolet1225!")
+            String password,
+            @Schema(description = "클라이언트 식별자", example = "nonce123")
+            String nonce
+    ) {
+        public PasswordChangeRequest {
+            validateNotBlank(password, AUTH_PASSWORD_REQUIRED);
+            password = password.strip();
+
+            // 비밀번호 정규식 검증
+            final String PASSWORD_REGEX = "^[A-Za-z\\d!\"#$%&'()*+,\\-./:;<=>?@\\[\\]^_`{|}~]+$";
+            validateRegex(password, PASSWORD_REGEX, AUTH_PASSWORD_INVALID_FORMAT);
+        }
+    }
 
     @Schema(description = "로그인 응답")
     public record LoginResponse(


### PR DESCRIPTION
## Issues
- Resolves #79 
- Resolves #413 
- Resolves #414
 
## Description

- 비밀번호 변경 기능 구현

- [POST] `/password/verify`
  - 로그인 유저가 비밀번호 변경 전, 본인 확인을 위해 비밀번호를 재인증

- [POST] `/password/change`
  - 로그인 및 재인증한 유저에 한해 비밀번호 변경 진행

<br />

## Review Points

- 자유로운 리뷰 부탁드립니다.

<br />

## How Has This Been Tested?

- 포스트맨 API 테스트로 비밀번호 재인증과 비밀번호 변경 기능 동작을 확인했습니다.

<br />

## Additional Notes

- 기능을 명확하게 구분하기 위해 사용자가 비로그인 상태에서 비밀번호를 잊었을 때 사용하는 기능인 **비밀번호 찾기(재설정)**, 사용자가 로그인 상태에서 마이페이지를 통해 진행되는 **비밀번호 변경** 기능을 별도의 이슈로 분리했습니다.
- 사용자의 안전한 비밀번호 설정을 위한, **비밀번호 히스토리 관리 기능**은 이후에 고도화를 진행하려 합니다.