### PR TITLE
Common: `./local-compose` 스크립트가 호스트의 JDK를 요구하지 않도록 수정합니다.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # 1. Base image: OpenJDK 21 slim
 FROM openjdk:21-slim
 
-# 2. 환경 변수로 local 프로필 지정 → 도커 컴포즈에서 제공 (도커 파일은 여러 환경에 실행될 수 있어야 하므로 이곳에서 주입 X)
+# 2. 환경 변수로 local 프로파일 지정 → 도커 컴포즈에서 제공 (도커 파일은 여러 환경에 실행될 수 있어야 하므로 이곳에서 주입 X)
 #ENV SPRING_PROFILES_ACTIVE=local
 
 # 3. 작업 디렉토리 설정

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # 1. Base image: OpenJDK 21 slim
 FROM openjdk:21-slim
 
-# 2. 환경 변수로 local 프로필 지정
+# 2. 환경 변수로 local 프로필 지정 → 도커 컴포즈에서 제공 (도커 파일은 여러 환경에 실행될 수 있어야 하므로 이곳에서 주입 X)
 #ENV SPRING_PROFILES_ACTIVE=local
 
 # 3. 작업 디렉토리 설정

--- a/local-compose
+++ b/local-compose
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
-chmod +x ./monolith-compose ./gradlew
+
+# ---- Gradle Wrapper in Docker (no host JDK needed) ----
+GW_IMAGE="gradle:8.10.1-jdk21"
+gw() {
+  docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -e HOME=/home/gradle \
+    -v "$PWD":/workspace \
+    -v "$HOME/.gradle":/home/gradle/.gradle \
+    -w /workspace \
+    "$GW_IMAGE" \
+    ./gradlew "$@"
+}
+
+# get permission to execute (exe-뀨뜨 >_< 권한 획득)
+chmod +x ./monolith-compose || true # 오류 무시
 
 # 파일 확인
 if [[ ! -f "docker-compose-local.yml" ]]; then
@@ -15,13 +30,8 @@ docker image inspect gradle:8.10.1-jdk21 >/dev/null 2>&1 || docker pull gradle:8
 
 if [[ ! -f monolith/main-runner/build/libs/main-runner-0.0.1-SNAPSHOT.jar ]]; then
   echo "main-runner JAR이 없어 빌드합니다..."
-  ./gradlew --version
-  docker run --rm \
-    -v "$PWD":/workspace \
-    -v "$HOME/.gradle":/home/gradle/.gradle \
-    -w /workspace \
-    gradle:8.10.1-jdk21 \
-    ./gradlew :main-runner:bootJar --no-daemon
+  gw --version
+  gw :main-runner:bootJar --no-daemon
 fi
 
 # 1) 인프라 기동

--- a/local-compose.ps1
+++ b/local-compose.ps1
@@ -1,4 +1,23 @@
 param()
+$ErrorActionPreference = "Stop"
+
+# ---- Gradle Wrapper in Docker (no host JDK needed) ----
+$GW_IMAGE = "gradle:8.10.1-jdk21"
+function gw {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+    docker run --rm `
+        -e HOME=/home/gradle `
+        -v "$(Get-Location):/workspace" `
+        -v "${env:USERPROFILE}\.gradle:/home/gradle/.gradle" `
+        -w /workspace `
+        $GW_IMAGE `
+        ./gradlew $Args
+}
+
+# 권한 설정 생략 (윈도우는 생략)
+# if (Test-Path "./monolith-compose") {
+#     try { icacls .\monolith-compose /grant Everyone:RX | Out-Null } catch {}
+# }
 
 # 파일 확인
 if (-not (Test-Path "./docker-compose-local.yml")) {
@@ -14,13 +33,8 @@ if (-not (docker image inspect gradle:8.10.1-jdk21 2>$null)) { docker pull gradl
 # JAR 확인 및 빌드
 if (-not (Test-Path "monolith/main-runner/build/libs/main-runner-0.0.1-SNAPSHOT.jar")) {
     Write-Host "main-runner JAR이 없어 빌드합니다..."
-    ./gradlew --version
-    docker run --rm `
-        -v "${PWD}:/workspace" `
-        -v "$HOME/.gradle:/home/gradle/.gradle" `
-        -w /workspace `
-        gradle:8.10.1-jdk21 `
-        ./gradlew :main-runner:bootJar --no-daemon
+    gw --version
+    gw :main-runner:bootJar --no-daemon
     if ($LASTEXITCODE -ne 0) { exit 1 }
 }
 
@@ -34,14 +48,13 @@ Write-Host "인프라 헬스체크 대기 중..."
 foreach ($s in $services) {
     Write-Host " - $s: " -NoNewline
     $tries = 0
-    while ($true) {
-        $cid = docker compose -f docker-compose-monolith.yml ps -q $s 2>$null
-        if (-not $cid) { Start-Sleep -Seconds 2; continue }
-        $status = docker inspect -f '{{.State.Health.Status}}' $cid 2>$null
-        if ($status -eq "healthy") {
-            Write-Host " OK"
-            break
+    do {
+        $containerId = docker compose -f docker-compose-monolith.yml ps -q $s
+        $status = ""
+        if ($containerId) {
+            $status = docker inspect -f '{{.State.Health.Status}}' $containerId 2>$null
         }
+        if ($status -eq "healthy") { break }
         $tries++
         if ($tries -gt 180) {
             Write-Host "시간 초과(≈15분). 상태를 확인하세요."
@@ -49,22 +62,29 @@ foreach ($s in $services) {
         }
         Write-Host -NoNewline "."
         Start-Sleep -Seconds 5
-    }
+    } while ($true)
+    Write-Host " OK"
 }
 
 # 3) 앱 기동
 docker compose -f docker-compose-local.yml up -d --build
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
-Write-Output "🚃 로컬 앱 부트 시작: http://localhost:8080"
+Write-Host "🚃 로컬 앱 부트 시작: http://localhost:8080"
 
-Write-Output "앱 헬스체크 대기 중..."
+Write-Host "앱 헬스체크 대기 중..."
+
 $tries = 0
 $response = ""
-
 while ([string]::IsNullOrEmpty($response)) {
     try {
-        $response = curl -s http://localhost:8080/actuator/health | Out-String
+        if ($PSVersionTable.PSVersion.Major -lt 6) {
+            # PowerShell 5.x (Windows PowerShell)
+            $response = Invoke-RestMethod -Uri "http://localhost:8080/actuator/health" -UseBasicParsing
+        } else {
+            # PowerShell 6+ (Core/7 이상)
+            $response = Invoke-RestMethod -Uri "http://localhost:8080/actuator/health"
+        }
     } catch {
         $response = ""
     }
@@ -84,8 +104,8 @@ if ($response -match '"status":"([^"]*)"') {
 }
 
 switch ($status) {
-    "UP"   { $presentation = "✅ 정상 기동" }
-    "DOWN" { $presentation = "❌ 일부 기능 작동하지 않음" }
+    "UP"    { $presentation = "✅ 정상 기동" }
+    "DOWN"  { $presentation = "❌ 일부 기능 작동하지 않음" }
     default { $presentation = "⚠️ 기타" }
 }
 


### PR DESCRIPTION

<br /><br />

<table border="3" align="center">
<tr height="45">
  <td width="45" align="center">🤖</td>
  <td align="center"><strong>이 문서는 인공지능으로 작성하였습니다.</strong></td>
</tr>
</table>

<br />

## Issues

- Resolves #424
  - Resolves #426
  - Resolves #427

## Description

> 스크립트마다 그레이들 래퍼 함수를 선언하고, 이곳에서 호스트 JDK 대신 풀 받은 JDK 및 그레이들을 사용하도록 위임받습니다.

- 로컬 개발 환경을 도커 중심으로 정비했습니다. (`feature/docker-local`)
  - `docker-compose-local.yml` 정리 및 서비스별 환경 변수 일원화
  - Gradle Wrapper를 컨테이너에서 실행하기 위한 `gw` 헬퍼 추가/정비(Windows PowerShell & Bash 대응, 캐시 볼륨 마운트)
  - `Dockerfile` 주석 및 활성 프로파일 위임(Compose에서 `SPRING_PROFILES_ACTIVE` 지정) 정리
  - 프록시/NO_PROXY 전달 규칙과 기본 네트워크 설정 가이드 반영
  - 헬스체크/의존성(`depends_on`) 정돈 및 로깅 가독성 개선
- 관련 이슈: #424

<br />

## Review Points

- **프로파일 위임**: `Dockerfile`에서 프로파일을 고정하지 않고 Compose에서 `SPRING_PROFILES_ACTIVE=local`로 위임한 설계가 적절한지
- **Gradle 컨테이너 빌드 플로우**: `gradle:8.10.1-jdk21` 사용, `$HOME/.gradle`(Unix) / `%USERPROFILE%\.gradle`(Windows) 캐시 마운트 경로 검증
- **권한/사용자 매핑**: Unix에서 `-u "$(id -u):$(id -g)"` 적용 여부, Windows 환경에서의 호환성
- **프록시 전달**: `HTTP_PROXY/HTTPS_PROXY/NO_PROXY` 전달 방식과 사내 네트워크 우회 도메인 관리 방법
- **헬스체크 및 의존 순서**: DB/Redis 등 종속 서비스 준비 전 애플리케이션 기동 방지 로직 확인
- **로컬 개발 DX**: `docker compose up -d` → `gw build` 흐름이 팀 공통 플로우로 무리가 없는지

<br />
<table border="1" align="center">
<tr>
  <td>
  
  [**리뷰하러 가기**](./429/files)
  
  </td>
</tr>
</table>

<br />

## How Has This Been Tested?

- macOS(로컬 Docker Desktop) 및 Windows 11(24H2, OS 빌드 26100.4946)에서 `docker compose -f docker-compose-local.yml up -d`로 기동
- `gw build` / `gw bootRun`로 애플리케이션 빌드 및 기동 확인
- `http://localhost:8080` 접속 및 컨테이너 로그로 헬스체크 성공 확인
- 실행하여 육안으로 확인하였습니다.
- AI 제안
  - `compose`에 `healthcheck` 재시도 간격/타임아웃 세분화
  - `env_file`로 프록시/NO_PROXY 관리(팀 공통화)
  - Hadolint 도입 및 Docker BuildKit 캐시 최적화
  - ARM/AMD 호환 베이스 이미지 태그 명시 및 `platform` 지정
  - 간단한 스모크 스크립트(`curl -fS http://localhost:8080/actuator/health`) 추가

<br />

## Additional Notes

- develop 대비 변경 내용: https://github.com/nettee-space/nettee-blolet-backend/compare/develop...feature/docker-local
- 알려진 사항: 사내 프록시 환경에서는 `NO_PROXY`에 내부 도메인/프라이빗 레지스트리를 포함해야 DNS/인증 이슈가 완화됩니다. 팀 표준 `.env.local` 템플릿으로 관리하는 것을 권장합니다.
