### PR TITLE
Auth: 로그인 시 loginId 대신 email을 사용해야 합니다.

### DIFF
--- a/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/dummy/R__init_dummies.sql
@@ -27,21 +27,18 @@ SET LOCAL dummy.USER_ENCODED_PASSWORD =
 
 INSERT INTO "auth"."user" (
     "id",
-    "login_id",
     "username",
     "encoded_password",
     "nickname",
     "email"
 ) VALUES (
     current_setting('dummy.USER_ID')::bigint,
-    'sun123',
     current_setting('dummy.USERNAME')::varchar,
     current_setting('dummy.USER_ENCODED_PASSWORD')::varchar,
     '동굴',
     'sun@gmail.com'
 ), (
     current_setting('dummy.USER_ID2')::bigint,
-    'moon123',
     current_setting('dummy.USERNAME2')::varchar,
     -- raw password: Blolet1225!
     current_setting('dummy.USER_ENCODED_PASSWORD')::varchar,

--- a/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
+++ b/monolith/main-runner/src/main/resources/db/migration/v1/V1_0_1__create_tb_user.sql
@@ -2,7 +2,7 @@ CREATE SCHEMA IF NOT EXISTS "auth";
 
 CREATE TABLE IF NOT EXISTS "auth"."user" (
     "id"	            BIGINT         ,
-    "login_id"	        VARCHAR(255)   ,
+    "email"	            VARCHAR(255)   ,
     -- 인증
     "username"	        VARCHAR(255)   ,
     "encoded_password"	VARCHAR(255)   ,
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS "auth"."user" (
     "locked_until"	    TIMESTAMP      ,
     -- 프로필 비정규화
     "nickname"	        VARCHAR(255)   ,
-    "email"	            VARCHAR(255)   ,
     -- 공통 컬럼
     "status"	        INT	            DEFAULT 20          NOT NULL,
     "created_at"	    TIMESTAMP		DEFAULT NOW()       NOT NULL,
@@ -19,19 +18,18 @@ CREATE TABLE IF NOT EXISTS "auth"."user" (
 );
 
 COMMENT ON COLUMN "auth"."user"."id"                  IS '사용자 테이블 PK';
-COMMENT ON COLUMN "auth"."user"."login_id"            IS '로그인 ID';
+COMMENT ON COLUMN "auth"."user"."email"               IS '사용자 이메일 주소(로그인 ID)';
 COMMENT ON COLUMN "auth"."user"."username"            IS '사용자의실명';
 COMMENT ON COLUMN "auth"."user"."encoded_password"    IS '로그인 비밀번호';
 COMMENT ON COLUMN "auth"."user"."login_retry_count"   IS '로그인 실패 횟수';
 COMMENT ON COLUMN "auth"."user"."locked_until"        IS '계정 잠금 해제 예정 시각, 잠금 시 사용';
 COMMENT ON COLUMN "auth"."user"."nickname"            IS '사용자닉네임';
-COMMENT ON COLUMN "auth"."user"."email"               IS '사용자의 이메일 주소';
 COMMENT ON COLUMN "auth"."user"."status"              IS
         '사용자 계정 상태 코드: PENDING(10, 가입 대기), ACTIVE(20, 활동), SUSPENDED(30, 정지), PROTECTED(40, 보호), REMOVED(0, 탈퇴)';
 COMMENT ON COLUMN "auth"."user"."created_at"          IS '생성일자';
 COMMENT ON COLUMN "auth"."user"."updated_at"          IS '수정일자';
 
 ALTER TABLE "auth"."user" ADD CONSTRAINT "pk_user" PRIMARY KEY ("id");
+ALTER TABLE "auth"."user" ADD CONSTRAINT "uq_user_email" UNIQUE ("email");
 ALTER TABLE "auth"."user" ADD CONSTRAINT "uq_user_username" UNIQUE ("username");
 ALTER TABLE "auth"."user" ADD CONSTRAINT "uq_user_nickname" UNIQUE ("nickname");
-ALTER TABLE "auth"."user" ADD CONSTRAINT "uq_user_email" UNIQUE ("email");

--- a/services/auth/api/domain/src/main/java/nettee/auth/domain/User.java
+++ b/services/auth/api/domain/src/main/java/nettee/auth/domain/User.java
@@ -14,11 +14,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class User {
     private String id;
-    private String loginId;
-    private String encodedPassword;
     private String username;
-    private String nickname;
     private String email;
+    private String encodedPassword;
+    private String nickname;
     private UserStatus status;
 
     private Integer loginRetryCount;

--- a/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
+++ b/services/auth/api/exception/src/main/java/nettee/auth/exception/AuthErrorCode.java
@@ -8,7 +8,6 @@ import java.util.function.Supplier;
 
 public enum AuthErrorCode implements ErrorCode {
     // web 요청 관련 오류
-    AUTH_LOGIN_ID_REQUIRED("로그인 ID는 필수입니다.", HttpStatus.BAD_REQUEST),
     AUTH_USERNAME_REQUIRED("사용자 이름은 필수입니다.", HttpStatus.BAD_REQUEST),
     AUTH_PASSWORD_REQUIRED("비밀번호는 필수입니다.", HttpStatus.BAD_REQUEST),
     AUTH_PASSWORD_INVALID_FORMAT("비밀번호 형식이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/services/auth/api/readmodel/src/main/java/nettee/blolet/auth/readmodel/AuthCommandModels.java
+++ b/services/auth/api/readmodel/src/main/java/nettee/blolet/auth/readmodel/AuthCommandModels.java
@@ -5,11 +5,10 @@ import lombok.Builder;
 public final class AuthCommandModels {
 
     public record SignUpRequestModel(
-            String loginId,
             String username,
+            String email,
             String password,
             String nickname,
-            String email,
 
             boolean agreedTerms,    // 이용약관 동의
             boolean agreedPrivacy   // 개인정보처리방침 동의

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthCommandRepositoryPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthCommandRepositoryPort.java
@@ -1,6 +1,5 @@
 package nettee.auth.port;
 
-import java.lang.ScopedValue;
 import java.util.Optional;
 import nettee.auth.domain.User;
 
@@ -15,4 +14,5 @@ public interface AuthCommandRepositoryPort {
     // 데이터 정합성이 중요한 경우에 사용
     Optional<User> findById(String userId);
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/services/auth/application/src/main/java/nettee/auth/port/AuthQueryRepositoryPort.java
+++ b/services/auth/application/src/main/java/nettee/auth/port/AuthQueryRepositoryPort.java
@@ -1,9 +1,4 @@
 package nettee.auth.port;
 
-import java.util.Optional;
-import nettee.auth.domain.User;
-
 public interface AuthQueryRepositoryPort {
-    Optional<User> findByLoginId(String loginId);
-    boolean existsByLoginId(String loginId);
 }

--- a/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
+++ b/services/auth/application/src/main/java/nettee/auth/service/AuthCommandService.java
@@ -28,9 +28,8 @@ import nettee.auth.domain.User;
 import nettee.auth.domain.UserStatus;
 import nettee.auth.exception.AuthException;
 import nettee.auth.port.AuthCommandRepositoryPort;
-import nettee.auth.port.AuthQueryRepositoryPort;
-import nettee.auth.port.AuthRedisPort;
 import nettee.auth.port.AuthMailSender;
+import nettee.auth.port.AuthRedisPort;
 import nettee.auth.usecase.AuthSignUsecase;
 import nettee.blolet.auth.readmodel.AuthCommandModels.LoginTokenModel;
 import nettee.blolet.auth.readmodel.AuthCommandModels.SignUpRequestModel;
@@ -44,7 +43,6 @@ import org.springframework.stereotype.Service;
 public class AuthCommandService implements AuthSignUsecase {
 
     private final AuthCommandRepositoryPort authCommandRepositoryPort;
-    private final AuthQueryRepositoryPort authQueryRepositoryPort;
     private final AuthRedisPort authRedisPort;
 
     private final PasswordEncoder passwordEncoder;
@@ -78,8 +76,8 @@ public class AuthCommandService implements AuthSignUsecase {
         // 1. 필수 약관 동의 여부 확인
         User.validateAgreed(model.agreedTerms(), model.agreedPrivacy());
 
-        // 2. login ID 중복 체크
-        boolean exists = authQueryRepositoryPort.existsByLoginId(model.loginId());
+        // 2. email 중복 체크
+        boolean exists = authCommandRepositoryPort.existsByEmail(model.email());
         if (exists) {
             throw new AuthException(AUTH_ACCOUNT_ALREADY_EXIST);
         }
@@ -89,11 +87,10 @@ public class AuthCommandService implements AuthSignUsecase {
 
         // 4. user 도메인 객체 생성
         User user = User.builder()
-                .loginId(model.loginId())
-                .encodedPassword(encodedPassword)
                 .username(model.username())
-                .nickname(model.nickname())
                 .email(model.email())
+                .encodedPassword(encodedPassword)
+                .nickname(model.nickname())
                 .status(UserStatus.ACTIVE) // 기본 상태는 ACTIVE
                 .build();
 
@@ -105,9 +102,9 @@ public class AuthCommandService implements AuthSignUsecase {
     }
 
     @Override
-    public LoginTokenModel signIn(String loginId, String rawPassword) throws AuthException {
-        // 1. login ID로 사용자 조회
-        User userEntity = authQueryRepositoryPort.findByLoginId(loginId)
+    public LoginTokenModel signIn(String email, String rawPassword) throws AuthException {
+        // 1. email 사용자 조회
+        User userEntity = authCommandRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AUTH_ACCOUNT_LOGIN_FAILED));
 
         // 2. 비밀번호 검증

--- a/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
+++ b/services/auth/application/src/main/java/nettee/auth/usecase/AuthSignUsecase.java
@@ -5,7 +5,7 @@ import nettee.blolet.auth.readmodel.AuthCommandModels.SignUpRequestModel;
 
 public interface AuthSignUsecase {
     LoginTokenModel signUp(SignUpRequestModel signUpRequest);
-    LoginTokenModel signIn(String loginId, String password);
+    LoginTokenModel signIn(String email, String password);
 
     String sendOtp(String email);
     String verifyOtp(String email, String otp, String nonce);

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthCommandRepositoryAdapter.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthCommandRepositoryAdapter.java
@@ -51,4 +51,9 @@ public class AuthCommandRepositoryAdapter implements AuthCommandRepositoryPort {
         Optional<UserEntity> userEntity = authJpaRepository.findByEmail(email);
         return userEntity.map(mapper::toDomain);
     }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return authJpaRepository.existsByEmail(email);
+    }
 }

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthQueryRepositoryAdapter.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/adapter/AuthQueryRepositoryAdapter.java
@@ -1,10 +1,7 @@
 package nettee.auth.rdb.adapter;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import nettee.auth.domain.User;
 import nettee.auth.port.AuthQueryRepositoryPort;
-import nettee.auth.rdb.entity.UserEntity;
 import nettee.auth.rdb.mapper.UserEntityMapper;
 import nettee.auth.rdb.repository.AuthJpaRepository;
 import org.springframework.stereotype.Component;
@@ -15,15 +12,4 @@ public class AuthQueryRepositoryAdapter implements AuthQueryRepositoryPort {
 
     private final AuthJpaRepository authJpaRepository;
     private final UserEntityMapper mapper;
-
-    @Override
-    public Optional<User> findByLoginId(String loginId) {
-        Optional<UserEntity> userEntity = authJpaRepository.findByLoginId(loginId);
-        return userEntity.map(mapper::toDomain);
-    }
-
-    @Override
-    public boolean existsByLoginId(String loginId) {
-        return authJpaRepository.existsByLoginId(loginId);
-    }
 }

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/entity/UserEntity.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/entity/UserEntity.java
@@ -19,9 +19,6 @@ import nettee.jpa.support.SnowflakeBaseTimeEntity;
 public class UserEntity extends SnowflakeBaseTimeEntity {
 
     @Column(unique = true)
-    private String loginId;
-
-    @Column(unique = true)
     private String username;
 
     @Column(unique = true)

--- a/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/repository/AuthJpaRepository.java
+++ b/services/auth/driven/rdb/src/main/java/nettee/auth/rdb/repository/AuthJpaRepository.java
@@ -5,7 +5,6 @@ import nettee.auth.rdb.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthJpaRepository extends JpaRepository<UserEntity, Long> {
-    Optional<UserEntity> findByLoginId(String loginId);
-    boolean existsByLoginId(String loginId);
+    boolean existsByEmail(String email);
     Optional<UserEntity> findByEmail(String email);
 }

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/AuthCommandApi.java
@@ -70,7 +70,7 @@ public class AuthCommandApi {
     )
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
         // 로그인 로직 구현
-        LoginTokenModel responseModel = authSignUsecase.signIn(loginRequest.loginId(), loginRequest.password());
+        LoginTokenModel responseModel = authSignUsecase.signIn(loginRequest.email(), loginRequest.password());
         LoginResponse result = mapper.toDto(responseModel);
 
         ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(responseModel.refreshToken());

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
@@ -1,7 +1,6 @@
 package nettee.auth.web.dto;
 
 import static nettee.auth.exception.AuthErrorCode.AUTH_EMAIL_REQUIRED;
-import static nettee.auth.exception.AuthErrorCode.AUTH_LOGIN_ID_REQUIRED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_NONCE_REQUIRED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_OTP_REQUIRED;
 import static nettee.auth.exception.AuthErrorCode.AUTH_PASSWORD_INVALID_FORMAT;
@@ -20,14 +19,12 @@ public final class AuthCommandDto {
 
     @Schema(description = "회원가입 요청")
     public record SignUpRequest(
-            @Schema(description = "로그인 ID", example = "sun123")
-            String loginId,
             @Schema(description = "사용자 이름", example = "sun")
             String username,
-            @Schema(description = "비밀번호", example = "Blolet1225!")
-            String password,
             @Schema(description = "이메일", example = "sun@gmail.com")
             String email,
+            @Schema(description = "비밀번호", example = "Blolet1225!")
+            String password,
             @Schema(description = "이용 약관 동의 여부", example = "true")
             boolean agreedTerms,
             @Schema(description = "개인정보 처리 방침 동의 여부", example = "true")
@@ -35,21 +32,19 @@ public final class AuthCommandDto {
     ) {
         public SignUpRequest {
             // 필수 값 검증
-            validateNotBlank(loginId, AUTH_LOGIN_ID_REQUIRED);
             validateNotBlank(username, AUTH_USERNAME_REQUIRED);
-            validateNotBlank(password, AUTH_PASSWORD_REQUIRED);
             validateNotBlank(email, AUTH_EMAIL_REQUIRED);
+            validateNotBlank(password, AUTH_PASSWORD_REQUIRED);
 
-            loginId = loginId.strip();
             username = username.strip();
-            password = password.strip();
             email = email.strip();
+            password = password.strip();
 
             // 정규식 검증
-            final String PASSWORD_REGEX = "^[A-Za-z\\d!\"#$%&'()*+,\\-./:;<=>?@\\[\\]^_`{|}~]+$";
             final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
-            validateRegex(password, PASSWORD_REGEX, AUTH_PASSWORD_INVALID_FORMAT);
+            final String PASSWORD_REGEX = "^[A-Za-z\\d!\"#$%&'()*+,\\-./:;<=>?@\\[\\]^_`{|}~]+$";
             validateRegex(email, EMAIL_REGEX, AUTH_EMAIL_REQUIRED);
+            validateRegex(password, PASSWORD_REGEX, AUTH_PASSWORD_INVALID_FORMAT);
 
             // 비밀번호 길이 검증
             validateLength(password, 8, 64, AUTH_PASSWORD_INVALID_LENGTH);
@@ -59,16 +54,16 @@ public final class AuthCommandDto {
     @Schema(description = "로그인 요청")
     public record LoginRequest(
             @Schema(description = "로그인 ID", example = "sun123")
-            String loginId,
+            String email,
             @Schema(description = "비밀번호", example = "Blolet1225!")
             String password
     ) {
         public LoginRequest {
             // 필수 값 검증
-            validateNotBlank(loginId, AUTH_LOGIN_ID_REQUIRED);
+            validateNotBlank(email, AUTH_EMAIL_REQUIRED);
             validateNotBlank(password, AUTH_PASSWORD_REQUIRED);
 
-            loginId = loginId.strip();
+            email = email.strip();
             password = password.strip();
 
             // 비밀번호 정규식 검증

--- a/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
+++ b/services/auth/driving/web-mvc/src/main/java/nettee/auth/web/dto/AuthCommandDto.java
@@ -53,7 +53,7 @@ public final class AuthCommandDto {
 
     @Schema(description = "로그인 요청")
     public record LoginRequest(
-            @Schema(description = "로그인 ID", example = "sun123")
+            @Schema(description = "이메일", example = "sun@gmail.com")
             String email,
             @Schema(description = "비밀번호", example = "Blolet1225!")
             String password
@@ -134,7 +134,7 @@ public final class AuthCommandDto {
             validateRegex(newPassword, PASSWORD_REGEX, AUTH_PASSWORD_INVALID_FORMAT);
         }
     }
-    
+
     @Schema(description = "비밀번호 변경 전 재인증")
     public record PasswordVerifyRequest(
             @Schema(description = "기존 비밀번호", example = "Blolet1225!")


### PR DESCRIPTION
## Issues

- Resolves #356 

## Description

- 로그인 시, loginId 대신 email을 로그인 식별자로 사용하도록 수정했습니다.

- flyway
  - auth.user 테이블에서 login_id 컬럼 삭제

- auth 모듈
  - web, application, rdb 계층 전반에서 사용되었던 loginId를 삭제하고 email을 사용하도록 수정

<br />

## Review Points

- 자유로운 리뷰 부탁드립니다.

<br />

## How Has This Been Tested?

- 포스트맨 API 테스트로 email로의 회원가입 및 로그인 요청이 정상 동작함을 확인했습니다.

<br />